### PR TITLE
BER-84: Implement Core Appointment Happy-Path Workflow Validation in src/backend/core

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The core directory contains fundamental application code:
 - **Configuration**: Settings, constants, and configuration parameters used throughout the application.
 - **Utilities**: Helper functions, decorators, middleware, and other utility classes or functions.
 - **Custom Exceptions**: Custom exception classes that are used throughout the application.
-- **Workflow Validation**: Core appointment happy-path validation (title normalization and time window checks) before persistence.
+- **Workflow Validation**: Core appointment happy-path validation before persistence, including title normalization (trim + whitespace collapsing), business-hour enforcement (09:00-17:00), and overlap conflict detection.
 
 ### 2. Routes
 The routes directory defines HTTP routes (endpoints) for the FastAPI application:
@@ -171,4 +171,3 @@ The application includes a comprehensive Docker Compose configuration with the f
 All data is persisted using Docker volumes:
 - `postgres_data`: Database data
 - `redis_data`: Redis data
-

--- a/src/backend/core/__init__.py
+++ b/src/backend/core/__init__.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, time
 
 
 @dataclass(frozen=True, slots=True)
@@ -9,25 +9,62 @@ class AppointmentWindow:
     end_time: datetime
 
 
+BUSINESS_HOUR_START = time(9, 0)
+BUSINESS_HOUR_END = time(17, 0)
+
+
+def normalize_appointment_title(title: str) -> str:
+    return " ".join(title.split())
+
+
+def validate_appointment_time_window(start_time: datetime, end_time: datetime) -> None:
+    if end_time <= start_time:
+        raise ValueError("end_time must be after start_time")
+
+    start_tod = start_time.time()
+    end_tod = end_time.time()
+    if start_tod < BUSINESS_HOUR_START or end_tod > BUSINESS_HOUR_END:
+        raise ValueError("appointment must be within business hours (09:00-17:00)")
+
+
 def validate_appointment_window(
     title: str, start_time: datetime, end_time: datetime
 ) -> AppointmentWindow:
-    normalized_title = title.strip()
+    normalized_title = normalize_appointment_title(title)
     if not normalized_title:
         raise ValueError("title must not be empty")
 
-    if end_time <= start_time:
-        raise ValueError("end_time must be after start_time")
+    validate_appointment_time_window(start_time, end_time)
 
     return AppointmentWindow(
         title=normalized_title, start_time=start_time, end_time=end_time
     )
 
 
+async def has_appointment_conflict(
+    conn, start_time: datetime, end_time: datetime
+) -> bool:
+    conflicting = await conn.fetch(
+        """
+        SELECT 1
+        FROM appointments
+        WHERE start_time < $2
+          AND end_time > $1
+        LIMIT 1
+        """,
+        start_time,
+        end_time,
+    )
+    return bool(conflicting)
+
+
 async def run_appointment_happy_path(
     conn, title: str, start_time: datetime, end_time: datetime
 ) -> AppointmentWindow:
     window = validate_appointment_window(title, start_time, end_time)
+    if await has_appointment_conflict(conn, window.start_time, window.end_time):
+        raise ValueError("appointment conflicts with an existing booking")
+
     await conn.execute(
         "INSERT INTO appointments (title, start_time, end_time) VALUES ($1, $2, $3)",
         window.title,
@@ -39,6 +76,11 @@ async def run_appointment_happy_path(
 
 __all__ = [
     "AppointmentWindow",
+    "BUSINESS_HOUR_END",
+    "BUSINESS_HOUR_START",
+    "has_appointment_conflict",
+    "normalize_appointment_title",
     "run_appointment_happy_path",
+    "validate_appointment_time_window",
     "validate_appointment_window",
 ]

--- a/tests/test_core_workflow.py
+++ b/tests/test_core_workflow.py
@@ -7,11 +7,20 @@ from src.backend.core import run_appointment_happy_path
 
 
 class FakeConn:
-    def __init__(self):
+    def __init__(self, existing=None):
         self.calls = []
+        self.existing = existing or []
 
     async def execute(self, query, *args):
         self.calls.append((query, args))
+
+    async def fetch(self, query, *args):
+        self.calls.append((query, args))
+        start_time, end_time = args
+        for existing_start, existing_end in self.existing:
+            if existing_start < end_time and existing_end > start_time:
+                return [1]
+        return []
 
 
 def test_run_appointment_happy_path_persists_valid_window():
@@ -20,18 +29,21 @@ def test_run_appointment_happy_path_persists_valid_window():
     end_time = datetime(2026, 1, 10, 11, 0, 0)
 
     result = asyncio.run(
-        run_appointment_happy_path(conn, "  Haircut  ", start_time, end_time)
+        run_appointment_happy_path(
+            conn, "  Haircut   Appointment  ", start_time, end_time
+        )
     )
 
-    assert result.title == "Haircut"
+    assert result.title == "Haircut Appointment"
     assert result.start_time == start_time
     assert result.end_time == end_time
-    assert conn.calls == [
-        (
-            "INSERT INTO appointments (title, start_time, end_time) VALUES ($1, $2, $3)",
-            ("Haircut", start_time, end_time),
-        )
-    ]
+    assert len(conn.calls) == 2
+    assert "FROM appointments" in conn.calls[0][0]
+    assert conn.calls[0][1] == (start_time, end_time)
+    assert conn.calls[1] == (
+        "INSERT INTO appointments (title, start_time, end_time) VALUES ($1, $2, $3)",
+        ("Haircut Appointment", start_time, end_time),
+    )
 
 
 def test_run_appointment_happy_path_rejects_invalid_time_range():
@@ -43,3 +55,32 @@ def test_run_appointment_happy_path_rejects_invalid_time_range():
         asyncio.run(run_appointment_happy_path(conn, "Haircut", start_time, end_time))
 
     assert conn.calls == []
+
+
+def test_run_appointment_happy_path_rejects_outside_business_hours():
+    conn = FakeConn()
+    start_time = datetime(2026, 1, 10, 8, 30, 0)
+    end_time = datetime(2026, 1, 10, 9, 30, 0)
+
+    with pytest.raises(
+        ValueError, match="appointment must be within business hours \\(09:00-17:00\\)"
+    ):
+        asyncio.run(run_appointment_happy_path(conn, "Haircut", start_time, end_time))
+
+    assert conn.calls == []
+
+
+def test_run_appointment_happy_path_rejects_conflicting_window():
+    existing_start = datetime(2026, 1, 10, 10, 30, 0)
+    existing_end = datetime(2026, 1, 10, 11, 30, 0)
+    conn = FakeConn(existing=[(existing_start, existing_end)])
+    start_time = datetime(2026, 1, 10, 10, 0, 0)
+    end_time = datetime(2026, 1, 10, 11, 0, 0)
+
+    with pytest.raises(
+        ValueError, match="appointment conflicts with an existing booking"
+    ):
+        asyncio.run(run_appointment_happy_path(conn, "Haircut", start_time, end_time))
+
+    assert len(conn.calls) == 1
+    assert "FROM appointments" in conn.calls[0][0]


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Linked Linear Ticket
Fixes BER-84
https://linear.app/baek/issue/BER-84/implement-core-appointment-happy-path-workflow-validation-in

## Instruction
Implement Linear ticket BER-84: Implement Core Appointment Happy-Path Workflow Validation in src/backend/core.
Linear URL: https://linear.app/baek/issue/BER-84/implement-core-appointment-happy-path-workflow-validation-in

Ticket description:
# Summary

Implement the core appointment happy-path validation logic within the `src/backend/core` module to ensure data correctness before persistence. This involves applying title normalization and verifying appointment time windows following the documented business rules.

# Scope

* Develop validation functions for appointment titles (normalization and formatting).
* Implement checks for valid appointment time windows (no conflicts, within business hours).
* Integrate these validations into the core workflow before database persistence.
* Add unit tests under `tests/test_core_workflow.py` covering the happy path.

# Acceptance Criteria

* Appointment titles are normalized according to spec before saving.
* Invalid time windows are correctly detected and rejected.
* Validation logic is fully covered by automated tests.
* Changes documented in `README.md` under Core -> Workflow Validation section if necessary.

# Helpful Files

* `src/backend/core/__init__.py` (core logic entrypoint)
* `tests/test_core_workflow.py` (testing workflow correctness)
* `README.md` (core workflow overview)

# Out of Scope

* Full workflow or state machine redesign.
* Frontend/UI validation.
* External API or AI integration.

## Codex Output
### Initial Draft
> Implemented BER-84 with focused changes in core workflow validation and tests.
>
> Changed files:
> - [src/backend/core/__init__.py](/var/lib/berry/pr-drafts/github.com-bryanbaek-pypy/worktrees/1e4ba89b-6b18-47b2-9b76-b39ce3990adc/repo/src/backend/core/__init__.py)
> - [tests/test_core_workflow.py](/var/lib/berry/pr-drafts/github.com-bryanbaek-pypy/worktrees/1e4ba89b-6b18-47b2-9b76-b39ce3990adc/repo/t...

## Validation
- `just lint`: passed
- `just test`: passed

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.ruff_cache`, `.venv`