### PR TITLE
BER-86: Implement and Verify Core Appointment Happy-Path Flow Validation

### DIFF
--- a/src/backend/core/__init__.py
+++ b/src/backend/core/__init__.py
@@ -21,6 +21,9 @@ def validate_appointment_time_window(start_time: datetime, end_time: datetime) -
     if end_time <= start_time:
         raise ValueError("end_time must be after start_time")
 
+    if start_time.date() != end_time.date():
+        raise ValueError("appointment must start and end on the same day")
+
     start_tod = start_time.time()
     end_tod = end_time.time()
     if start_tod < BUSINESS_HOUR_START or end_tod > BUSINESS_HOUR_END:

--- a/tests/test_core_workflow.py
+++ b/tests/test_core_workflow.py
@@ -70,6 +70,19 @@ def test_run_appointment_happy_path_rejects_outside_business_hours():
     assert conn.calls == []
 
 
+def test_run_appointment_happy_path_rejects_cross_day_window():
+    conn = FakeConn()
+    start_time = datetime(2026, 1, 10, 16, 0, 0)
+    end_time = datetime(2026, 1, 11, 10, 0, 0)
+
+    with pytest.raises(
+        ValueError, match="appointment must start and end on the same day"
+    ):
+        asyncio.run(run_appointment_happy_path(conn, "Haircut", start_time, end_time))
+
+    assert conn.calls == []
+
+
 def test_run_appointment_happy_path_rejects_conflicting_window():
     existing_start = datetime(2026, 1, 10, 10, 30, 0)
     existing_end = datetime(2026, 1, 10, 11, 30, 0)
@@ -84,3 +97,31 @@ def test_run_appointment_happy_path_rejects_conflicting_window():
 
     assert len(conn.calls) == 1
     assert "FROM appointments" in conn.calls[0][0]
+
+
+def test_run_appointment_happy_path_allows_edge_aligned_non_overlapping_window():
+    existing_start = datetime(2026, 1, 10, 10, 0, 0)
+    existing_end = datetime(2026, 1, 10, 11, 0, 0)
+    conn = FakeConn(existing=[(existing_start, existing_end)])
+    start_time = datetime(2026, 1, 10, 11, 0, 0)
+    end_time = datetime(2026, 1, 10, 12, 0, 0)
+
+    result = asyncio.run(
+        run_appointment_happy_path(conn, " Follow Up ", start_time, end_time)
+    )
+
+    assert result.title == "Follow Up"
+    assert len(conn.calls) == 2
+    assert "FROM appointments" in conn.calls[0][0]
+    assert conn.calls[1][1] == ("Follow Up", start_time, end_time)
+
+
+def test_run_appointment_happy_path_rejects_empty_normalized_title():
+    conn = FakeConn()
+    start_time = datetime(2026, 1, 10, 10, 0, 0)
+    end_time = datetime(2026, 1, 10, 11, 0, 0)
+
+    with pytest.raises(ValueError, match="title must not be empty"):
+        asyncio.run(run_appointment_happy_path(conn, "   \t   ", start_time, end_time))
+
+    assert conn.calls == []


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Linked Linear Ticket
Fixes BER-86
https://linear.app/baek/issue/BER-86/implement-and-verify-core-appointment-happy-path-flow-validation

## Instruction
Implement Linear ticket BER-86: Implement and Verify Core Appointment Happy-Path Flow Validation.
Linear URL: https://linear.app/baek/issue/BER-86/implement-and-verify-core-appointment-happy-path-flow-validation

Ticket description:
# Summary

Implement a robust validation of the appointment booking workflow's happy path within the `src/backend/core` directory, ensuring adherence to business rules like title normalization, business hours enforcement, and overlap conflict detection prior to database persistence.

# Scope

* Enhance and verify the core validation logic for appointment creation workflows.
* Include title normalization (trim and whitespace collapsing), business-hour enforcement (09:00-17:00), and conflict detection for overlapping appointments.
* Write or extend automated tests to cover these validations in `tests/test_core_workflow.py`.

# Acceptance Criteria

* Appointment validation logic correctly normalizes titles.
* Business hours are strictly enforced for all appointments.
* Overlapping appointment conflicts are detected and prevented.
* Automated tests pass verifying all validation behaviors.
* Changes isolated within `src/backend/core` modules without introducing regressions.

# Helpful Files

* `src/backend/core/__init__.py` (core app logic)
* `tests/test_core_workflow.py` (testing happy-path workflows)
* `README.md` (architecture and workflow overview)

# Out of Scope

* Changes to database layers in `src/backend/db`.
* HTTP route modifications or UI adjustments.
* Non-happy-path error handling enhancements.

## Codex Output
### Initial Draft
> Implemented BER-86 with a minimal, scoped diff in core workflow validation and tests.
>
> **Files changed**
> - [src/backend/core/__init__.py](/var/lib/berry/pr-drafts/github.com-bryanbaek-pypy/worktrees/7abbf317-0d99-4b63-b017-dc0cb2a4d6a3/repo/src/backend/core/__init__.py)
> - [tests/test_core_workflow.py](/var/lib/berry/pr-drafts/github.com-bryanbaek-pypy/worktrees/7abbf317-0d99-4b63-b017-dc0cb2a4d...

## Validation
- `just lint`: passed
- `just test`: passed

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.ruff_cache`, `.venv`