### PR TITLE
BER-88: Implement Happy-Path Appointment Validation in core Workflow Module

### DIFF
--- a/src/backend/db/postgres.py
+++ b/src/backend/db/postgres.py
@@ -1,13 +1,10 @@
 import asyncpg  # type: ignore
 
+from src.backend.core import run_appointment_happy_path
+
 
 async def create_appointment(conn, title, start_time, end_time):
-    await conn.execute(
-        "INSERT INTO appointments (title, start_time, end_time) VALUES ($1, $2, $3)",
-        title,
-        start_time,
-        end_time,
-    )
+    return await run_appointment_happy_path(conn, title, start_time, end_time)
 
 
 async def get_appointments(conn):

--- a/tests/test_core_workflow.py
+++ b/tests/test_core_workflow.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import pytest
 
 from src.backend.core import run_appointment_happy_path
+from src.backend.db.postgres import create_appointment
 
 
 class FakeConn:
@@ -172,3 +173,48 @@ def test_run_appointment_happy_path_normalizes_multiline_whitespace():
     assert result.title == "Intake Consultation Session"
     assert len(conn.calls) == 2
     assert conn.calls[1][1] == ("Intake Consultation Session", start_time, end_time)
+
+
+def test_create_appointment_applies_happy_path_validation_and_normalization():
+    conn = FakeConn()
+    start_time = datetime(2026, 1, 10, 10, 0, 0)
+    end_time = datetime(2026, 1, 10, 11, 0, 0)
+
+    result = asyncio.run(
+        create_appointment(conn, "  New   Client\n Intake  ", start_time, end_time)
+    )
+
+    assert result.title == "New Client Intake"
+    assert result.start_time == start_time
+    assert result.end_time == end_time
+    assert len(conn.calls) == 2
+    assert "FROM appointments" in conn.calls[0][0]
+    assert conn.calls[1][1] == ("New Client Intake", start_time, end_time)
+
+
+def test_create_appointment_rejects_conflicting_windows_via_core_validation():
+    existing_start = datetime(2026, 1, 10, 10, 30, 0)
+    existing_end = datetime(2026, 1, 10, 11, 30, 0)
+    conn = FakeConn(existing=[(existing_start, existing_end)])
+    start_time = datetime(2026, 1, 10, 10, 0, 0)
+    end_time = datetime(2026, 1, 10, 11, 0, 0)
+
+    with pytest.raises(
+        ValueError, match="appointment conflicts with an existing booking"
+    ):
+        asyncio.run(create_appointment(conn, "Haircut", start_time, end_time))
+
+    assert len(conn.calls) == 1
+
+
+def test_create_appointment_rejects_outside_business_hours_via_core_validation():
+    conn = FakeConn()
+    start_time = datetime(2026, 1, 10, 8, 59, 0)
+    end_time = datetime(2026, 1, 10, 9, 30, 0)
+
+    with pytest.raises(
+        ValueError, match="appointment must be within business hours \\(09:00-17:00\\)"
+    ):
+        asyncio.run(create_appointment(conn, "Haircut", start_time, end_time))
+
+    assert conn.calls == []


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Linked Linear Ticket
Fixes BER-88
https://linear.app/baek/issue/BER-88/implement-happy-path-appointment-validation-in-core-workflow-module

## Instruction
Implement Linear ticket BER-88: Implement Happy-Path Appointment Validation in core Workflow Module.
Linear URL: https://linear.app/baek/issue/BER-88/implement-happy-path-appointment-validation-in-core-workflow-module

Ticket description:
# Summary

Implement the core appointment validation logic according to the documented happy-path workflow in the `src/backend/core` module. This includes enforcing title normalization, business-hour constraints, and overlap conflict detection before appointment data is persisted.

# Scope

* Develop and integrate validation functions for:
  * Title normalization (trimming and whitespace collapsing)
  * Business-hour enforcement (appointments within 09:00 to 17:00 on the same day)
  * Appointment overlap conflict detection
* Ensure validation is applied consistently during appointment creation flow.
* Add or update unit tests in `tests/test_core_workflow.py` to cover these validations.

# Acceptance Criteria

* Title normalization is applied to all new appointment titles.
* Appointments outside business hours or spanning multiple days are rejected with proper error handling.
* Overlapping appointments are detected and prevented.
* Tests verify all validation rules with edge cases.
* Code changes are documented and adhere to existing style.

# Helpful Files

* `src/backend/core/__init__.py` (existing core workflow logic)
* `tests/test_core_workflow.py` (test cases for core workflows)
* `README.md` (overview of core validation rules)

# Out of Scope

* Implementation of non-happy-path error recovery workflows.
* Changes to database schema or persistence beyond validation logic.
* Frontend or route-layer changes; this focuses on backend core logic only.

## Codex Output
### Initial Draft
> Implemented BER-88 with a minimal integration diff so appointment creation consistently uses the core happy-path validator.
>
> **Files changed**
> - [src/backend/db/postgres.py](/var/lib/berry/pr-drafts/github.com-bryanbaek-pypy/worktrees/2001a0d0-8bf7-47d2-ac8d-5b901c74e6cd/repo/src/backend/db/postgres.py:1)
> - [tests/test_core_workflow.py](/var/lib/berry/pr-drafts/github.com-bryanbaek-pypy/worktre...

## Validation
- `just lint`: passed
- `just test`: passed

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.ruff_cache`, `.venv`