### PR TITLE
BER-91: Add appointment workflow slice with repository, gateway, controller, and handlers plus tests in sandbox repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ The services directory contains business logic:
 - **Database Operations**: CRUD operations and other database-related logic.
 - **AI Services**: Integration with OpenAI, Google Gemini, and Groq AI models.
 
+### 4. Sandbox Workflow Slice
+The `sandbox/appointment` package provides a minimal layered appointment flow for orchestration practice:
+
+- **Repository**: Persistence and overlap query operations.
+- **Gateway**: Abstraction over repository/data-access interactions.
+- **Controller**: Workflow orchestration using core validation (title normalization, business-hour checks, conflict rejection).
+- **Handlers**: Request-payload translation and response shaping for service/API style entrypoints.
+
 ## Setup
 
 ### Install dependencies

--- a/sandbox/__init__.py
+++ b/sandbox/__init__.py
@@ -1,0 +1,1 @@
+"""Sandbox modules for isolated workflow slices."""

--- a/sandbox/appointment/__init__.py
+++ b/sandbox/appointment/__init__.py
@@ -1,0 +1,11 @@
+"""Appointment workflow slice with repository, gateway, controller, and handlers."""
+
+from sandbox.appointment.controller import AppointmentController
+from sandbox.appointment.gateway import AppointmentGateway
+from sandbox.appointment.handlers import handle_create_appointment
+
+__all__ = [
+    "AppointmentController",
+    "AppointmentGateway",
+    "handle_create_appointment",
+]

--- a/sandbox/appointment/controller.py
+++ b/sandbox/appointment/controller.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+
+from src.backend.core import validate_appointment_window
+
+
+class AppointmentController:
+    def __init__(self, gateway):
+        self._gateway = gateway
+
+    async def create_appointment(
+        self, title: str, start_time: datetime, end_time: datetime
+    ) -> dict:
+        window = validate_appointment_window(title, start_time, end_time)
+
+        if await self._gateway.has_conflict(window.start_time, window.end_time):
+            raise ValueError("appointment conflicts with an existing booking")
+
+        return await self._gateway.create_appointment(
+            window.title,
+            window.start_time,
+            window.end_time,
+        )

--- a/sandbox/appointment/gateway.py
+++ b/sandbox/appointment/gateway.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+
+from . import repository as default_repository
+
+
+class AppointmentGateway:
+    def __init__(self, conn, repository=default_repository):
+        self._conn = conn
+        self._repository = repository
+
+    async def has_conflict(self, start_time: datetime, end_time: datetime) -> bool:
+        return await self._repository.has_conflict(self._conn, start_time, end_time)
+
+    async def create_appointment(
+        self, title: str, start_time: datetime, end_time: datetime
+    ) -> dict:
+        return await self._repository.create_appointment(
+            self._conn, title, start_time, end_time
+        )

--- a/sandbox/appointment/handlers.py
+++ b/sandbox/appointment/handlers.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+
+
+def _as_datetime(value):
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        return datetime.fromisoformat(value)
+    raise ValueError("start_time and end_time must be datetime or ISO datetime strings")
+
+
+async def handle_create_appointment(controller, payload: dict) -> dict:
+    try:
+        appointment = await controller.create_appointment(
+            title=payload["title"],
+            start_time=_as_datetime(payload["start_time"]),
+            end_time=_as_datetime(payload["end_time"]),
+        )
+    except (KeyError, ValueError) as exc:
+        return {"status": "error", "error": str(exc)}
+
+    return {"status": "ok", "appointment": appointment}

--- a/sandbox/appointment/repository.py
+++ b/sandbox/appointment/repository.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+
+
+async def has_conflict(conn, start_time: datetime, end_time: datetime) -> bool:
+    conflicting = await conn.fetch(
+        """
+        SELECT 1
+        FROM appointments
+        WHERE start_time < $2
+          AND end_time > $1
+        LIMIT 1
+        """,
+        start_time,
+        end_time,
+    )
+    return bool(conflicting)
+
+
+async def create_appointment(
+    conn, title: str, start_time: datetime, end_time: datetime
+) -> dict:
+    await conn.execute(
+        "INSERT INTO appointments (title, start_time, end_time) VALUES ($1, $2, $3)",
+        title,
+        start_time,
+        end_time,
+    )
+    return {"title": title, "start_time": start_time, "end_time": end_time}

--- a/tests/test_sandbox_appointment_workflow.py
+++ b/tests/test_sandbox_appointment_workflow.py
@@ -1,0 +1,198 @@
+import asyncio
+from datetime import datetime
+
+import pytest
+
+from sandbox.appointment.controller import AppointmentController
+from sandbox.appointment.gateway import AppointmentGateway
+from sandbox.appointment.handlers import handle_create_appointment
+from sandbox.appointment.repository import create_appointment, has_conflict
+
+
+class FakeConn:
+    def __init__(self, existing=None):
+        self.calls = []
+        self.existing = existing or []
+
+    async def execute(self, query, *args):
+        self.calls.append((query, args))
+
+    async def fetch(self, query, *args):
+        self.calls.append((query, args))
+        start_time, end_time = args
+        for existing_start, existing_end in self.existing:
+            if existing_start < end_time and existing_end > start_time:
+                return [1]
+        return []
+
+
+class FakeRepository:
+    def __init__(self, conflict=False):
+        self.conflict = conflict
+        self.calls = []
+
+    async def has_conflict(self, conn, start_time, end_time):
+        self.calls.append(("has_conflict", conn, start_time, end_time))
+        return self.conflict
+
+    async def create_appointment(self, conn, title, start_time, end_time):
+        self.calls.append(("create_appointment", conn, title, start_time, end_time))
+        return {"title": title, "start_time": start_time, "end_time": end_time}
+
+
+class FakeGateway:
+    def __init__(self, conflict=False):
+        self.conflict = conflict
+        self.calls = []
+
+    async def has_conflict(self, start_time, end_time):
+        self.calls.append(("has_conflict", start_time, end_time))
+        return self.conflict
+
+    async def create_appointment(self, title, start_time, end_time):
+        self.calls.append(("create_appointment", title, start_time, end_time))
+        return {"title": title, "start_time": start_time, "end_time": end_time}
+
+
+def test_repository_has_conflict_returns_true_when_overlapping_window_exists():
+    existing_start = datetime(2026, 1, 10, 10, 30, 0)
+    existing_end = datetime(2026, 1, 10, 11, 30, 0)
+    conn = FakeConn(existing=[(existing_start, existing_end)])
+
+    start_time = datetime(2026, 1, 10, 10, 0, 0)
+    end_time = datetime(2026, 1, 10, 11, 0, 0)
+
+    result = asyncio.run(has_conflict(conn, start_time, end_time))
+
+    assert result is True
+    assert len(conn.calls) == 1
+    assert "FROM appointments" in conn.calls[0][0]
+
+
+def test_repository_create_appointment_persists_and_returns_payload():
+    conn = FakeConn()
+    start_time = datetime(2026, 1, 10, 12, 0, 0)
+    end_time = datetime(2026, 1, 10, 13, 0, 0)
+
+    result = asyncio.run(create_appointment(conn, "Consultation", start_time, end_time))
+
+    assert result == {
+        "title": "Consultation",
+        "start_time": start_time,
+        "end_time": end_time,
+    }
+    assert conn.calls == [
+        (
+            "INSERT INTO appointments (title, start_time, end_time) VALUES ($1, $2, $3)",
+            ("Consultation", start_time, end_time),
+        )
+    ]
+
+
+def test_gateway_delegates_to_repository_with_connection_context():
+    conn = object()
+    repository = FakeRepository(conflict=False)
+    gateway = AppointmentGateway(conn, repository=repository)
+    start_time = datetime(2026, 1, 10, 10, 0, 0)
+    end_time = datetime(2026, 1, 10, 11, 0, 0)
+
+    conflict = asyncio.run(gateway.has_conflict(start_time, end_time))
+    created = asyncio.run(gateway.create_appointment("Title", start_time, end_time))
+
+    assert conflict is False
+    assert created["title"] == "Title"
+    assert repository.calls == [
+        ("has_conflict", conn, start_time, end_time),
+        ("create_appointment", conn, "Title", start_time, end_time),
+    ]
+
+
+def test_controller_applies_core_validation_and_normalizes_title():
+    gateway = FakeGateway(conflict=False)
+    controller = AppointmentController(gateway)
+    start_time = datetime(2026, 1, 10, 9, 0, 0)
+    end_time = datetime(2026, 1, 10, 10, 0, 0)
+
+    result = asyncio.run(
+        controller.create_appointment("  Intake   Session  ", start_time, end_time)
+    )
+
+    assert result["title"] == "Intake Session"
+    assert gateway.calls == [
+        ("has_conflict", start_time, end_time),
+        ("create_appointment", "Intake Session", start_time, end_time),
+    ]
+
+
+def test_controller_rejects_conflicting_appointment_window():
+    gateway = FakeGateway(conflict=True)
+    controller = AppointmentController(gateway)
+    start_time = datetime(2026, 1, 10, 10, 0, 0)
+    end_time = datetime(2026, 1, 10, 11, 0, 0)
+
+    with pytest.raises(
+        ValueError, match="appointment conflicts with an existing booking"
+    ):
+        asyncio.run(controller.create_appointment("Haircut", start_time, end_time))
+
+    assert gateway.calls == [("has_conflict", start_time, end_time)]
+
+
+def test_controller_rejects_outside_business_hours_before_gateway_call():
+    gateway = FakeGateway(conflict=False)
+    controller = AppointmentController(gateway)
+    start_time = datetime(2026, 1, 10, 8, 59, 0)
+    end_time = datetime(2026, 1, 10, 9, 30, 0)
+
+    with pytest.raises(
+        ValueError, match="appointment must be within business hours \\(09:00-17:00\\)"
+    ):
+        asyncio.run(controller.create_appointment("Haircut", start_time, end_time))
+
+    assert gateway.calls == []
+
+
+def test_handler_returns_error_for_invalid_payload():
+    gateway = FakeGateway(conflict=False)
+    controller = AppointmentController(gateway)
+
+    result = asyncio.run(
+        handle_create_appointment(
+            controller,
+            {
+                "title": "Haircut",
+                "start_time": "not-a-datetime",
+                "end_time": "2026-01-10T11:00:00",
+            },
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "Invalid isoformat string" in result["error"]
+
+
+def test_handler_controller_gateway_repository_integration_happy_path():
+    conn = FakeConn()
+    gateway = AppointmentGateway(conn)
+    controller = AppointmentController(gateway)
+
+    result = asyncio.run(
+        handle_create_appointment(
+            controller,
+            {
+                "title": "  New   Client  Intake ",
+                "start_time": "2026-01-10T10:00:00",
+                "end_time": "2026-01-10T11:00:00",
+            },
+        )
+    )
+
+    assert result["status"] == "ok"
+    assert result["appointment"]["title"] == "New Client Intake"
+    assert len(conn.calls) == 2
+    assert "FROM appointments" in conn.calls[0][0]
+    assert conn.calls[1][1] == (
+        "New Client Intake",
+        datetime(2026, 1, 10, 10, 0, 0),
+        datetime(2026, 1, 10, 11, 0, 0),
+    )


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Linked Linear Ticket
Fixes BER-91
https://linear.app/baek/issue/BER-91/add-appointment-workflow-slice-with-repository-gateway-controller-and

## Instruction
Implement Linear ticket BER-91: Add appointment workflow slice with repository, gateway, controller, and handlers plus tests in sandbox repo.
Linear URL: https://linear.app/baek/issue/BER-91/add-appointment-workflow-slice-with-repository-gateway-controller-and

Ticket description:
# Summary

Implement a minimal but realistic appointment workflow slice in the `sandbox` directory that mirrors Berry-style layering. This involves creating the repository, gateway, controller, and handler modules to form the backend orchestration and service logic for appointment processing, along with comprehensive tests.

# Scope

* Scaffold `sandbox` directory if not present.
* Create layered modules:
  * Repository module handling data persistence logic.
  * Gateway module providing interface to database or external services.
  * Controller module orchestrating workflow logic.
  * Handler modules defining API or service handlers.
* Implement appointment workflow features based on the core appointment validation (title normalization, business hour enforcement, conflict detection) described in `src/backend/core`.
* Add unit and integration tests under `tests` targeting the new modules.

# Acceptance Criteria

* `sandbox` directory with layered modules (repository, gateway, controller, handler) created.
* Appointment workflow slice implemented that validates:
  * Title normalization.
  * Business hour enforcement.
  * Conflict detection.
* Tests covering all new modules with passing results.
* Code follows existing repository styling and architecture patterns.
* README or doc comments updated to briefly document the new workflow slice.

# Helpful Files

* `README.md` (proj overview and layering guidance)
* `src/backend/core/__init__.py` (validation logic reference)
* `tests/test_core_workflow.py` (example test structure)

# Out of Scope

* Full production appointment system.
* Frontend or UI components.
* AI integration logic.

## Codex Output
### Initial Draft
> Implemented BER-91 with a minimal layered appointment slice in `sandbox`, plus targeted tests and a README note.
>
> **Files changed**
> - Added [sandbox/__init__.py](/var/lib/berry/pr-drafts/github.com-bryanbaek-pypy/worktrees/f8037b6e-3c29-42dd-89e3-bd8bd05606b9/repo/sandbox/__init__.py)
> - Added [sandbox/appointment/__init__.py](/var/lib/berry/pr-drafts/github.com-bryanbaek-pypy/worktrees/f8037b6e...

## Validation
- `just lint`: passed
- `just test`: passed

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.ruff_cache`, `.venv`