### PR TITLE
BER-92: Implement Berry-Style Layered Appointment Workflow Slice in sandbox/appointment

### DIFF
--- a/sandbox/appointment/__init__.py
+++ b/sandbox/appointment/__init__.py
@@ -2,10 +2,20 @@
 
 from sandbox.appointment.controller import AppointmentController
 from sandbox.appointment.gateway import AppointmentGateway
-from sandbox.appointment.handlers import handle_create_appointment
+from sandbox.appointment.handlers import (
+    handle_create_appointment,
+    handle_delete_appointment,
+    handle_get_appointment,
+    handle_get_appointments,
+    handle_update_appointment,
+)
 
 __all__ = [
     "AppointmentController",
     "AppointmentGateway",
     "handle_create_appointment",
+    "handle_delete_appointment",
+    "handle_get_appointment",
+    "handle_get_appointments",
+    "handle_update_appointment",
 ]

--- a/sandbox/appointment/controller.py
+++ b/sandbox/appointment/controller.py
@@ -20,3 +20,51 @@ class AppointmentController:
             window.start_time,
             window.end_time,
         )
+
+    async def get_appointment(self, appointment_id: int) -> dict | None:
+        return await self._gateway.get_appointment(appointment_id)
+
+    async def get_appointments(self) -> list[dict]:
+        return await self._gateway.get_appointments()
+
+    async def update_appointment(
+        self,
+        appointment_id: int,
+        title: str | None = None,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+    ) -> dict:
+        existing = await self._gateway.get_appointment(appointment_id)
+        if existing is None:
+            raise ValueError("appointment not found")
+
+        window = validate_appointment_window(
+            title=existing["title"] if title is None else title,
+            start_time=existing["start_time"] if start_time is None else start_time,
+            end_time=existing["end_time"] if end_time is None else end_time,
+        )
+
+        if await self._gateway.has_conflict(
+            window.start_time,
+            window.end_time,
+            exclude_appointment_id=appointment_id,
+        ):
+            raise ValueError("appointment conflicts with an existing booking")
+
+        appointment = await self._gateway.update_appointment(
+            appointment_id,
+            window.title,
+            window.start_time,
+            window.end_time,
+        )
+        if appointment is None:
+            raise ValueError("appointment not found")
+        return appointment
+
+    async def delete_appointment(self, appointment_id: int) -> dict:
+        existing = await self._gateway.get_appointment(appointment_id)
+        if existing is None:
+            raise ValueError("appointment not found")
+
+        await self._gateway.delete_appointment(appointment_id)
+        return {"deleted_id": appointment_id}

--- a/sandbox/appointment/gateway.py
+++ b/sandbox/appointment/gateway.py
@@ -8,8 +8,18 @@ class AppointmentGateway:
         self._conn = conn
         self._repository = repository
 
-    async def has_conflict(self, start_time: datetime, end_time: datetime) -> bool:
-        return await self._repository.has_conflict(self._conn, start_time, end_time)
+    async def has_conflict(
+        self,
+        start_time: datetime,
+        end_time: datetime,
+        exclude_appointment_id: int | None = None,
+    ) -> bool:
+        return await self._repository.has_conflict(
+            self._conn,
+            start_time,
+            end_time,
+            exclude_appointment_id=exclude_appointment_id,
+        )
 
     async def create_appointment(
         self, title: str, start_time: datetime, end_time: datetime
@@ -17,3 +27,23 @@ class AppointmentGateway:
         return await self._repository.create_appointment(
             self._conn, title, start_time, end_time
         )
+
+    async def get_appointment(self, appointment_id: int) -> dict | None:
+        return await self._repository.get_appointment(self._conn, appointment_id)
+
+    async def get_appointments(self) -> list[dict]:
+        return await self._repository.get_appointments(self._conn)
+
+    async def update_appointment(
+        self,
+        appointment_id: int,
+        title: str,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> dict | None:
+        return await self._repository.update_appointment(
+            self._conn, appointment_id, title, start_time, end_time
+        )
+
+    async def delete_appointment(self, appointment_id: int) -> None:
+        await self._repository.delete_appointment(self._conn, appointment_id)

--- a/sandbox/appointment/handlers.py
+++ b/sandbox/appointment/handlers.py
@@ -20,3 +20,43 @@ async def handle_create_appointment(controller, payload: dict) -> dict:
         return {"status": "error", "error": str(exc)}
 
     return {"status": "ok", "appointment": appointment}
+
+
+async def handle_get_appointments(controller) -> dict:
+    appointments = await controller.get_appointments()
+    return {"status": "ok", "appointments": appointments}
+
+
+async def handle_get_appointment(controller, appointment_id: int) -> dict:
+    appointment = await controller.get_appointment(appointment_id)
+    if appointment is None:
+        return {"status": "error", "error": "appointment not found"}
+    return {"status": "ok", "appointment": appointment}
+
+
+async def handle_update_appointment(
+    controller, appointment_id: int, payload: dict
+) -> dict:
+    try:
+        appointment = await controller.update_appointment(
+            appointment_id=appointment_id,
+            title=payload.get("title"),
+            start_time=(
+                _as_datetime(payload["start_time"]) if "start_time" in payload else None
+            ),
+            end_time=_as_datetime(payload["end_time"])
+            if "end_time" in payload
+            else None,
+        )
+    except ValueError as exc:
+        return {"status": "error", "error": str(exc)}
+
+    return {"status": "ok", "appointment": appointment}
+
+
+async def handle_delete_appointment(controller, appointment_id: int) -> dict:
+    try:
+        deletion = await controller.delete_appointment(appointment_id)
+    except ValueError as exc:
+        return {"status": "error", "error": str(exc)}
+    return {"status": "ok", **deletion}

--- a/sandbox/appointment/repository.py
+++ b/sandbox/appointment/repository.py
@@ -1,28 +1,115 @@
 from datetime import datetime
 
 
-async def has_conflict(conn, start_time: datetime, end_time: datetime) -> bool:
-    conflicting = await conn.fetch(
-        """
-        SELECT 1
-        FROM appointments
-        WHERE start_time < $2
-          AND end_time > $1
-        LIMIT 1
-        """,
-        start_time,
-        end_time,
-    )
+def _row_to_appointment(row) -> dict | None:
+    if row is None:
+        return None
+    return {
+        "id": row["id"],
+        "title": row["title"],
+        "start_time": row["start_time"],
+        "end_time": row["end_time"],
+    }
+
+
+async def has_conflict(
+    conn,
+    start_time: datetime,
+    end_time: datetime,
+    exclude_appointment_id: int | None = None,
+) -> bool:
+    if exclude_appointment_id is None:
+        conflicting = await conn.fetch(
+            """
+            SELECT 1
+            FROM appointments
+            WHERE start_time < $2
+              AND end_time > $1
+            LIMIT 1
+            """,
+            start_time,
+            end_time,
+        )
+    else:
+        conflicting = await conn.fetch(
+            """
+            SELECT 1
+            FROM appointments
+            WHERE start_time < $2
+              AND end_time > $1
+              AND id != $3
+            LIMIT 1
+            """,
+            start_time,
+            end_time,
+            exclude_appointment_id,
+        )
     return bool(conflicting)
 
 
 async def create_appointment(
     conn, title: str, start_time: datetime, end_time: datetime
 ) -> dict:
-    await conn.execute(
-        "INSERT INTO appointments (title, start_time, end_time) VALUES ($1, $2, $3)",
+    row = await conn.fetchrow(
+        """
+        INSERT INTO appointments (title, start_time, end_time)
+        VALUES ($1, $2, $3)
+        RETURNING id, title, start_time, end_time
+        """,
         title,
         start_time,
         end_time,
     )
-    return {"title": title, "start_time": start_time, "end_time": end_time}
+    appointment = _row_to_appointment(row)
+    if appointment is None:
+        return {"title": title, "start_time": start_time, "end_time": end_time}
+    return appointment
+
+
+async def get_appointment(conn, appointment_id: int) -> dict | None:
+    row = await conn.fetchrow(
+        """
+        SELECT id, title, start_time, end_time
+        FROM appointments
+        WHERE id = $1
+        """,
+        appointment_id,
+    )
+    return _row_to_appointment(row)
+
+
+async def get_appointments(conn) -> list[dict]:
+    rows = await conn.fetch(
+        """
+        SELECT id, title, start_time, end_time
+        FROM appointments
+        ORDER BY start_time
+        """
+    )
+    return [appointment for row in rows if (appointment := _row_to_appointment(row))]
+
+
+async def update_appointment(
+    conn,
+    appointment_id: int,
+    title: str,
+    start_time: datetime,
+    end_time: datetime,
+) -> dict | None:
+    row = await conn.fetchrow(
+        """
+        UPDATE appointments
+        SET title = $1, start_time = $2, end_time = $3
+        WHERE id = $4
+        RETURNING id, title, start_time, end_time
+        """,
+        title,
+        start_time,
+        end_time,
+        appointment_id,
+    )
+    return _row_to_appointment(row)
+
+
+async def delete_appointment(conn, appointment_id: int) -> None:
+    await conn.execute("DELETE FROM appointments WHERE id = $1", appointment_id)

--- a/tests/test_sandbox_appointment_workflow.py
+++ b/tests/test_sandbox_appointment_workflow.py
@@ -5,25 +5,111 @@ import pytest
 
 from sandbox.appointment.controller import AppointmentController
 from sandbox.appointment.gateway import AppointmentGateway
-from sandbox.appointment.handlers import handle_create_appointment
-from sandbox.appointment.repository import create_appointment, has_conflict
+from sandbox.appointment.handlers import (
+    handle_create_appointment,
+    handle_delete_appointment,
+    handle_get_appointment,
+    handle_get_appointments,
+    handle_update_appointment,
+)
+from sandbox.appointment.repository import (
+    create_appointment,
+    delete_appointment,
+    get_appointment,
+    get_appointments,
+    has_conflict,
+    update_appointment,
+)
 
 
 class FakeConn:
     def __init__(self, existing=None):
         self.calls = []
-        self.existing = existing or []
+        self.appointments = []
+        self._next_id = 1
+
+        for existing_start, existing_end in existing or []:
+            self.appointments.append(
+                {
+                    "id": self._next_id,
+                    "title": f"Existing {self._next_id}",
+                    "start_time": existing_start,
+                    "end_time": existing_end,
+                }
+            )
+            self._next_id += 1
 
     async def execute(self, query, *args):
         self.calls.append((query, args))
+        if "DELETE FROM appointments" in query:
+            appointment_id = args[0]
+            self.appointments = [
+                appointment
+                for appointment in self.appointments
+                if appointment["id"] != appointment_id
+            ]
 
     async def fetch(self, query, *args):
         self.calls.append((query, args))
-        start_time, end_time = args
-        for existing_start, existing_end in self.existing:
-            if existing_start < end_time and existing_end > start_time:
-                return [1]
+
+        if "SELECT 1" in query and "FROM appointments" in query:
+            start_time, end_time = args[0], args[1]
+            exclude_appointment_id = args[2] if len(args) > 2 else None
+            for appointment in self.appointments:
+                if (
+                    exclude_appointment_id is not None
+                    and appointment["id"] == exclude_appointment_id
+                ):
+                    continue
+                if (
+                    appointment["start_time"] < end_time
+                    and appointment["end_time"] > start_time
+                ):
+                    return [1]
+            return []
+
+        if "SELECT id, title, start_time, end_time" in query and "ORDER BY" in query:
+            return sorted(
+                self.appointments, key=lambda appointment: appointment["start_time"]
+            )
+
         return []
+
+    async def fetchrow(self, query, *args):
+        self.calls.append((query, args))
+
+        if "INSERT INTO appointments" in query and "RETURNING" in query:
+            appointment = {
+                "id": self._next_id,
+                "title": args[0],
+                "start_time": args[1],
+                "end_time": args[2],
+            }
+            self._next_id += 1
+            self.appointments.append(appointment)
+            return appointment
+
+        if (
+            "SELECT id, title, start_time, end_time" in query
+            and "WHERE id = $1" in query
+        ):
+            appointment_id = args[0]
+            for appointment in self.appointments:
+                if appointment["id"] == appointment_id:
+                    return appointment
+            return None
+
+        if "UPDATE appointments" in query and "RETURNING" in query:
+            appointment_id = args[3]
+            for appointment in self.appointments:
+                if appointment["id"] == appointment_id:
+                    appointment["title"] = args[0]
+                    appointment["start_time"] = args[1]
+                    appointment["end_time"] = args[2]
+                    return appointment
+            return None
+
+        return None
 
 
 class FakeRepository:
@@ -31,27 +117,117 @@ class FakeRepository:
         self.conflict = conflict
         self.calls = []
 
-    async def has_conflict(self, conn, start_time, end_time):
-        self.calls.append(("has_conflict", conn, start_time, end_time))
+    async def has_conflict(
+        self, conn, start_time, end_time, exclude_appointment_id=None
+    ):
+        self.calls.append(
+            (
+                "has_conflict",
+                conn,
+                start_time,
+                end_time,
+                exclude_appointment_id,
+            )
+        )
         return self.conflict
 
     async def create_appointment(self, conn, title, start_time, end_time):
         self.calls.append(("create_appointment", conn, title, start_time, end_time))
-        return {"title": title, "start_time": start_time, "end_time": end_time}
+        return {
+            "id": 1,
+            "title": title,
+            "start_time": start_time,
+            "end_time": end_time,
+        }
+
+    async def get_appointment(self, conn, appointment_id):
+        self.calls.append(("get_appointment", conn, appointment_id))
+        return {
+            "id": appointment_id,
+            "title": "Title",
+            "start_time": datetime(2026, 1, 10, 10, 0, 0),
+            "end_time": datetime(2026, 1, 10, 11, 0, 0),
+        }
+
+    async def get_appointments(self, conn):
+        self.calls.append(("get_appointments", conn))
+        return []
+
+    async def update_appointment(
+        self, conn, appointment_id, title, start_time, end_time
+    ):
+        self.calls.append(
+            (
+                "update_appointment",
+                conn,
+                appointment_id,
+                title,
+                start_time,
+                end_time,
+            )
+        )
+        return {
+            "id": appointment_id,
+            "title": title,
+            "start_time": start_time,
+            "end_time": end_time,
+        }
+
+    async def delete_appointment(self, conn, appointment_id):
+        self.calls.append(("delete_appointment", conn, appointment_id))
 
 
 class FakeGateway:
     def __init__(self, conflict=False):
         self.conflict = conflict
         self.calls = []
+        self.appointments = {
+            1: {
+                "id": 1,
+                "title": "Initial",
+                "start_time": datetime(2026, 1, 10, 10, 0, 0),
+                "end_time": datetime(2026, 1, 10, 11, 0, 0),
+            }
+        }
 
-    async def has_conflict(self, start_time, end_time):
-        self.calls.append(("has_conflict", start_time, end_time))
+    async def has_conflict(self, start_time, end_time, exclude_appointment_id=None):
+        self.calls.append(
+            ("has_conflict", start_time, end_time, exclude_appointment_id)
+        )
         return self.conflict
 
     async def create_appointment(self, title, start_time, end_time):
         self.calls.append(("create_appointment", title, start_time, end_time))
-        return {"title": title, "start_time": start_time, "end_time": end_time}
+        return {
+            "id": 2,
+            "title": title,
+            "start_time": start_time,
+            "end_time": end_time,
+        }
+
+    async def get_appointment(self, appointment_id):
+        self.calls.append(("get_appointment", appointment_id))
+        return self.appointments.get(appointment_id)
+
+    async def get_appointments(self):
+        self.calls.append(("get_appointments",))
+        return list(self.appointments.values())
+
+    async def update_appointment(self, appointment_id, title, start_time, end_time):
+        self.calls.append(
+            ("update_appointment", appointment_id, title, start_time, end_time)
+        )
+        appointment = self.appointments.get(appointment_id)
+        if appointment is None:
+            return None
+        appointment["title"] = title
+        appointment["start_time"] = start_time
+        appointment["end_time"] = end_time
+        return appointment
+
+    async def delete_appointment(self, appointment_id):
+        self.calls.append(("delete_appointment", appointment_id))
+        self.appointments.pop(appointment_id, None)
 
 
 def test_repository_has_conflict_returns_true_when_overlapping_window_exists():
@@ -69,24 +245,35 @@ def test_repository_has_conflict_returns_true_when_overlapping_window_exists():
     assert "FROM appointments" in conn.calls[0][0]
 
 
-def test_repository_create_appointment_persists_and_returns_payload():
+def test_repository_crud_roundtrip():
     conn = FakeConn()
     start_time = datetime(2026, 1, 10, 12, 0, 0)
     end_time = datetime(2026, 1, 10, 13, 0, 0)
 
-    result = asyncio.run(create_appointment(conn, "Consultation", start_time, end_time))
+    created = asyncio.run(
+        create_appointment(conn, "Consultation", start_time, end_time)
+    )
+    fetched = asyncio.run(get_appointment(conn, created["id"]))
+    listing = asyncio.run(get_appointments(conn))
 
-    assert result == {
-        "title": "Consultation",
-        "start_time": start_time,
-        "end_time": end_time,
-    }
-    assert conn.calls == [
-        (
-            "INSERT INTO appointments (title, start_time, end_time) VALUES ($1, $2, $3)",
-            ("Consultation", start_time, end_time),
+    assert created["id"] == 1
+    assert fetched == created
+    assert listing == [created]
+
+    updated = asyncio.run(
+        update_appointment(
+            conn,
+            created["id"],
+            "Follow Up",
+            start_time,
+            datetime(2026, 1, 10, 14, 0, 0),
         )
-    ]
+    )
+    assert updated is not None
+    assert updated["title"] == "Follow Up"
+
+    asyncio.run(delete_appointment(conn, created["id"]))
+    assert asyncio.run(get_appointment(conn, created["id"])) is None
 
 
 def test_gateway_delegates_to_repository_with_connection_context():
@@ -98,12 +285,22 @@ def test_gateway_delegates_to_repository_with_connection_context():
 
     conflict = asyncio.run(gateway.has_conflict(start_time, end_time))
     created = asyncio.run(gateway.create_appointment("Title", start_time, end_time))
+    fetched = asyncio.run(gateway.get_appointment(3))
+    listing = asyncio.run(gateway.get_appointments())
+    asyncio.run(gateway.update_appointment(3, "Updated", start_time, end_time))
+    asyncio.run(gateway.delete_appointment(3))
 
     assert conflict is False
     assert created["title"] == "Title"
+    assert fetched is not None
+    assert listing == []
     assert repository.calls == [
-        ("has_conflict", conn, start_time, end_time),
+        ("has_conflict", conn, start_time, end_time, None),
         ("create_appointment", conn, "Title", start_time, end_time),
+        ("get_appointment", conn, 3),
+        ("get_appointments", conn),
+        ("update_appointment", conn, 3, "Updated", start_time, end_time),
+        ("delete_appointment", conn, 3),
     ]
 
 
@@ -119,7 +316,7 @@ def test_controller_applies_core_validation_and_normalizes_title():
 
     assert result["title"] == "Intake Session"
     assert gateway.calls == [
-        ("has_conflict", start_time, end_time),
+        ("has_conflict", start_time, end_time, None),
         ("create_appointment", "Intake Session", start_time, end_time),
     ]
 
@@ -135,7 +332,7 @@ def test_controller_rejects_conflicting_appointment_window():
     ):
         asyncio.run(controller.create_appointment("Haircut", start_time, end_time))
 
-    assert gateway.calls == [("has_conflict", start_time, end_time)]
+    assert gateway.calls == [("has_conflict", start_time, end_time, None)]
 
 
 def test_controller_rejects_outside_business_hours_before_gateway_call():
@@ -150,6 +347,38 @@ def test_controller_rejects_outside_business_hours_before_gateway_call():
         asyncio.run(controller.create_appointment("Haircut", start_time, end_time))
 
     assert gateway.calls == []
+
+
+def test_controller_update_validates_and_excludes_same_appointment_for_conflict_check():
+    gateway = FakeGateway(conflict=False)
+    controller = AppointmentController(gateway)
+
+    result = asyncio.run(
+        controller.update_appointment(
+            1,
+            title="  Updated   Session  ",
+            start_time=datetime(2026, 1, 10, 10, 30, 0),
+            end_time=datetime(2026, 1, 10, 11, 30, 0),
+        )
+    )
+
+    assert result["title"] == "Updated Session"
+    assert gateway.calls == [
+        ("get_appointment", 1),
+        (
+            "has_conflict",
+            datetime(2026, 1, 10, 10, 30, 0),
+            datetime(2026, 1, 10, 11, 30, 0),
+            1,
+        ),
+        (
+            "update_appointment",
+            1,
+            "Updated Session",
+            datetime(2026, 1, 10, 10, 30, 0),
+            datetime(2026, 1, 10, 11, 30, 0),
+        ),
+    ]
 
 
 def test_handler_returns_error_for_invalid_payload():
@@ -176,7 +405,7 @@ def test_handler_controller_gateway_repository_integration_happy_path():
     gateway = AppointmentGateway(conn)
     controller = AppointmentController(gateway)
 
-    result = asyncio.run(
+    created = asyncio.run(
         handle_create_appointment(
             controller,
             {
@@ -187,12 +416,34 @@ def test_handler_controller_gateway_repository_integration_happy_path():
         )
     )
 
-    assert result["status"] == "ok"
-    assert result["appointment"]["title"] == "New Client Intake"
-    assert len(conn.calls) == 2
-    assert "FROM appointments" in conn.calls[0][0]
-    assert conn.calls[1][1] == (
-        "New Client Intake",
-        datetime(2026, 1, 10, 10, 0, 0),
-        datetime(2026, 1, 10, 11, 0, 0),
+    assert created["status"] == "ok"
+    appointment_id = created["appointment"]["id"]
+    assert created["appointment"]["title"] == "New Client Intake"
+
+    fetched = asyncio.run(handle_get_appointment(controller, appointment_id))
+    assert fetched["status"] == "ok"
+    assert fetched["appointment"]["id"] == appointment_id
+
+    listing = asyncio.run(handle_get_appointments(controller))
+    assert listing["status"] == "ok"
+    assert len(listing["appointments"]) == 1
+
+    updated = asyncio.run(
+        handle_update_appointment(
+            controller,
+            appointment_id,
+            {
+                "title": "  Updated   Intake  ",
+                "start_time": "2026-01-10T10:15:00",
+                "end_time": "2026-01-10T11:15:00",
+            },
+        )
     )
+    assert updated["status"] == "ok"
+    assert updated["appointment"]["title"] == "Updated Intake"
+
+    deleted = asyncio.run(handle_delete_appointment(controller, appointment_id))
+    assert deleted == {"status": "ok", "deleted_id": appointment_id}
+
+    missing = asyncio.run(handle_get_appointment(controller, appointment_id))
+    assert missing == {"status": "error", "error": "appointment not found"}


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Linked Linear Ticket
Fixes BER-92
https://linear.app/baek/issue/BER-92/implement-berry-style-layered-appointment-workflow-slice-in

## Instruction
Implement Linear ticket BER-92: Implement Berry-Style Layered Appointment Workflow Slice in sandbox/appointment.
Linear URL: https://linear.app/baek/issue/BER-92/implement-berry-style-layered-appointment-workflow-slice-in

Ticket description:
# Summary

Implement a minimal but real appointment workflow slice in the `sandbox/appointment` package that mirrors the Berry core layering pattern. This will involve creating and scaffolding repository, gateway, controller, and handler modules along with corresponding tests to enable appointment orchestration practice with clear separation of concerns.

# Scope

* Scaffold the following modules within `sandbox/appointment` if they don't exist:
  * repository (for persistence and overlap query operations)
  * gateway (abstraction over repository and external integrations)
  * controller (core business logic coordinating gateway and repository calls)
  * handlers (HTTP endpoint handlers)
* Implement minimal real logic in each layer to support appointment creation and validation following existing core validation rules (e.g., business hours, overlap detection).
* Write unit and integration tests covering the end-to-end appointment flow in `tests/test_sandbox_appointment_workflow.py`.

# Acceptance Criteria

* `sandbox/appointment/repository.py` created with async CRUD and overlap check methods
* `sandbox/appointment/gateway.py` created to abstract repository calls
* `sandbox/appointment/controller.py` created implementing core appointment business logic
* `sandbox/appointment/handlers.py` created exposing HTTP endpoints for appointment operations
* Tests in `tests/test_sandbox_appointment_workflow.py` cover repository, gateway, controller, and handler layers
* Code follows repository patterns and style consistent with Berry core flow and the documented API layering

# Helpful Files

* `sandbox/appointment/` directory
* `tests/test_sandbox_appointment_workflow.py`
* [README.md](<http://README.md>) sections on sandbox workflow slice

# Out of Scope

* Integration with external AI services
* UI or frontend changes
* Advanced appointment features beyond basic validation and persistence

## Codex Output
### Initial Draft
> Implemented BER-92 with a minimal layered expansion of `sandbox/appointment` to include async CRUD + overlap checks across repository, gateway, controller, and handlers, plus expanded workflow tests.
>
> **Files changed**
> - [sandbox/appointment/repository.py](/var/lib/berry/pr-drafts/github.com-bryanbaek-pypy/worktrees/5c194043-75ee-4181-b17f-b99a693317eb/repo/sandbox/appointment/repository.py)
>   ...

## Validation
- `just lint`: passed
- `just test`: passed

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.ruff_cache`, `.venv`