### PR TITLE
Implement a small safe test change and add tests

### DIFF
--- a/src/backend/core/__init__.py
+++ b/src/backend/core/__init__.py
@@ -15,6 +15,8 @@ BUSINESS_HOUR_END = time(17, 0)
 
 def normalize_appointment_title(title: str) -> str:
     """Trim and collapse all whitespace in appointment titles."""
+    if not isinstance(title, str):
+        raise ValueError("title must be a string")
     return " ".join(title.split())
 
 

--- a/tests/test_core_workflow.py
+++ b/tests/test_core_workflow.py
@@ -159,6 +159,17 @@ def test_run_appointment_happy_path_rejects_empty_normalized_title():
     assert conn.calls == []
 
 
+def test_run_appointment_happy_path_rejects_non_string_title():
+    conn = FakeConn()
+    start_time = datetime(2026, 1, 10, 10, 0, 0)
+    end_time = datetime(2026, 1, 10, 11, 0, 0)
+
+    with pytest.raises(ValueError, match="title must be a string"):
+        asyncio.run(run_appointment_happy_path(conn, 123, start_time, end_time))
+
+    assert conn.calls == []
+
+
 def test_run_appointment_happy_path_normalizes_multiline_whitespace():
     conn = FakeConn()
     start_time = datetime(2026, 1, 10, 13, 0, 0)

--- a/tests/test_sandbox_appointment_workflow.py
+++ b/tests/test_sandbox_appointment_workflow.py
@@ -505,6 +505,25 @@ def test_handler_returns_error_for_missing_required_create_field():
     assert result["error"] == "'end_time'"
 
 
+def test_handler_returns_error_for_non_string_title():
+    gateway = FakeGateway(conflict=False)
+    controller = AppointmentController(gateway)
+
+    result = asyncio.run(
+        handle_create_appointment(
+            controller,
+            {
+                "title": 123,
+                "start_time": "2026-01-10T10:00:00",
+                "end_time": "2026-01-10T11:00:00",
+            },
+        )
+    )
+
+    assert result["status"] == "error"
+    assert result["error"] == "title must be a string"
+
+
 def test_handler_update_returns_error_for_invalid_payload():
     gateway = FakeGateway(conflict=False)
     controller = AppointmentController(gateway)


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Instruction
Implement a small safe test change and add tests.

## Codex Output
### Initial Draft
> Implemented a small safe validation change plus targeted tests.
>
> Changed files:
> - [src/backend/core/__init__.py](/job/repo/src/backend/core/__init__.py): added a defensive type check in `normalize_appointment_title` so non-string titles now raise `ValueError("title must be a string")` instead of causing an `AttributeError`.
> - [tests/test_core_workflow.py](/job/repo/tests/test_core_workflow.py):...

## Validation
- `just lint`: passed
- `just test`: passed

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.venv`