### PR TITLE
BER-96: Extend Sandbox Appointment Workflow to Produce Run-Specific Core MVP Happy-Path Verification Artifact

### DIFF
--- a/sandbox/appointment/e2e/core-mvp-20260319T170333Z-happy.md
+++ b/sandbox/appointment/e2e/core-mvp-20260319T170333Z-happy.md
@@ -1,0 +1,4 @@
+# Core MVP Happy-Path Verification Artifact
+
+tag: core-mvp-20260319T170333Z-happy
+scenario: happy-path

--- a/sandbox/appointment/handlers.py
+++ b/sandbox/appointment/handlers.py
@@ -1,7 +1,16 @@
 """Handler layer for translating payloads to controller operations."""
 
 from datetime import datetime
+from pathlib import Path
 from typing import Protocol
+
+HAPPY_PATH_ARTIFACT_TAG = "core-mvp-20260319T170333Z-happy"
+HAPPY_PATH_ARTIFACT_SCENARIO = "happy-path"
+HAPPY_PATH_ARTIFACT_PATH = (
+    Path(__file__).resolve().parent
+    / "e2e"
+    / f"{HAPPY_PATH_ARTIFACT_TAG}.md"
+)
 
 
 class AppointmentControllerContract(Protocol):
@@ -35,6 +44,19 @@ def _as_datetime(value: datetime | str) -> datetime:
     raise ValueError("start_time and end_time must be datetime or ISO datetime strings")
 
 
+def _write_happy_path_artifact() -> None:
+    """Write marker artifact for the sandbox appointment happy-path scenario."""
+    HAPPY_PATH_ARTIFACT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    HAPPY_PATH_ARTIFACT_PATH.write_text(
+        (
+            "# Core MVP Happy-Path Verification Artifact\n\n"
+            f"tag: {HAPPY_PATH_ARTIFACT_TAG}\n"
+            f"scenario: {HAPPY_PATH_ARTIFACT_SCENARIO}\n"
+        ),
+        encoding="utf-8",
+    )
+
+
 async def handle_create_appointment(
     controller: AppointmentControllerContract, payload: dict
 ) -> dict:
@@ -48,6 +70,7 @@ async def handle_create_appointment(
     except (KeyError, ValueError) as exc:
         return {"status": "error", "error": str(exc)}
 
+    _write_happy_path_artifact()
     return {"status": "ok", "appointment": appointment}
 
 

--- a/tests/test_sandbox_appointment_workflow.py
+++ b/tests/test_sandbox_appointment_workflow.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 import pytest
 
+from sandbox.appointment import handlers as appointment_handlers
 from sandbox.appointment.controller import AppointmentController
 from sandbox.appointment.gateway import AppointmentGateway
 from sandbox.appointment.handlers import (
@@ -633,3 +634,30 @@ def test_handler_controller_gateway_repository_rejects_overlapping_window():
         "status": "error",
         "error": "appointment conflicts with an existing booking",
     }
+
+
+def test_handler_happy_path_writes_core_mvp_verification_artifact(tmp_path, monkeypatch):
+    artifact_path = tmp_path / "core-mvp-20260319T170333Z-happy.md"
+    monkeypatch.setattr(
+        appointment_handlers, "HAPPY_PATH_ARTIFACT_PATH", artifact_path
+    )
+
+    gateway = FakeGateway(conflict=False)
+    controller = AppointmentController(gateway)
+
+    created = asyncio.run(
+        handle_create_appointment(
+            controller,
+            {
+                "title": "New Client Intake",
+                "start_time": "2026-01-10T10:00:00",
+                "end_time": "2026-01-10T11:00:00",
+            },
+        )
+    )
+
+    assert created["status"] == "ok"
+    assert artifact_path.exists()
+    artifact_content = artifact_path.read_text(encoding="utf-8")
+    assert "tag: core-mvp-20260319T170333Z-happy" in artifact_content
+    assert "scenario: happy-path" in artifact_content


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Linked Linear Ticket
Fixes BER-96
https://linear.app/baek/issue/BER-96/extend-sandbox-appointment-workflow-to-produce-run-specific-core-mvp

## Instruction
Implement the approved Berry ticket: Extend Sandbox Appointment Workflow to Produce Run-Specific Core MVP Happy-Path Verification Artifact.
Repository: https://github.com/bryanbaek/pypy
Base branch: main

Approved ticket description:
### Summary
Enhance the `sandbox/appointment` workflow to always generate a fresh, run-specific verification artifact tagged `core-mvp-20260319T170333Z-happy` for the happy-path scenario. Add a marker file at `sandbox/appointment/e2e/core-mvp-20260319T170333Z-happy.md` containing this tag and scenario name. Update or add tests under `tests/test_sandbox_appointment_workflow.py` or a new test file to assert the presence of this artifact. Maintain the existing repository/gateway/controller/handler flow with minimal changes.

### Scope
- Modify appointment workflow in `sandbox/appointment` to produce a run-specific artifact for verification.
- Add the marker file at `sandbox/appointment/e2e/core-mvp-20260319T170333Z-happy.md` with exact tag and scenario.
- Update existing or add new test(s) in `tests/` to assert artifact presence.
- Avoid altering the core flow logic or layering.

### Acceptance Criteria
- Run-specific artifact with tag `core-mvp-20260319T170333Z-happy` is generated on happy-path executions.
- `sandbox/appointment/e2e/core-mvp-20260319T170333Z-happy.md` exists and includes the exact tag and scenario.
- Test coverage verifies the artifact creation and correctness.
- Existing repository, gateway, controller, and handler code flow remains unchanged except minimal necessary augmentation.

### Helpful Files
- `sandbox/appointment/controller.py`
- `sandbox/appointment/gateway.py`
- `sandbox/appointment/handlers.py`
- `tests/test_sandbox_appointment_workflow.py`

### Out of Scope
- Changes to appointment overlap logic or business rules.
- Modifications to core workflow validation outside adding the artifact.
- Changes outside the sandbox appointment workflow area.

## Codex Output
### Initial Draft
> Implemented the ticket with a minimal workflow-layer change in `handlers` and a targeted test.
>
> **Files changed**
> - [sandbox/appointment/handlers.py](/job/repo/sandbox/appointment/handlers.py)
> - [sandbox/appointment/e2e/core-mvp-20260319T170333Z-happy.md](/job/repo/sandbox/appointment/e2e/core-mvp-20260319T170333Z-happy.md)
> - [tests/test_sandbox_appointment_workflow.py](/job/repo/tests/test_san...

## Validation
- `just lint`: passed
- `just test`: passed

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.venv`