### PR TITLE
BER-97: Add Run-Specific Happy-Path Artifact and Test Coverage for Core MVP Appointment Workflow

### DIFF
--- a/sandbox/appointment/e2e/core-mvp-20260319T173841Z-happy.md
+++ b/sandbox/appointment/e2e/core-mvp-20260319T173841Z-happy.md
@@ -1,0 +1,4 @@
+# Core MVP Happy-Path Verification Artifact
+
+tag: core-mvp-20260319T173841Z-happy
+scenario: happy

--- a/sandbox/appointment/handlers.py
+++ b/sandbox/appointment/handlers.py
@@ -4,8 +4,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Protocol
 
-HAPPY_PATH_ARTIFACT_TAG = "core-mvp-20260319T170333Z-happy"
-HAPPY_PATH_ARTIFACT_SCENARIO = "happy-path"
+HAPPY_PATH_ARTIFACT_TAG = "core-mvp-20260319T173841Z-happy"
+HAPPY_PATH_ARTIFACT_SCENARIO = "happy"
 HAPPY_PATH_ARTIFACT_PATH = (
     Path(__file__).resolve().parent
     / "e2e"

--- a/tests/test_sandbox_appointment_workflow.py
+++ b/tests/test_sandbox_appointment_workflow.py
@@ -637,7 +637,7 @@ def test_handler_controller_gateway_repository_rejects_overlapping_window():
 
 
 def test_handler_happy_path_writes_core_mvp_verification_artifact(tmp_path, monkeypatch):
-    artifact_path = tmp_path / "core-mvp-20260319T170333Z-happy.md"
+    artifact_path = tmp_path / "core-mvp-20260319T173841Z-happy.md"
     monkeypatch.setattr(
         appointment_handlers, "HAPPY_PATH_ARTIFACT_PATH", artifact_path
     )
@@ -659,5 +659,17 @@ def test_handler_happy_path_writes_core_mvp_verification_artifact(tmp_path, monk
     assert created["status"] == "ok"
     assert artifact_path.exists()
     artifact_content = artifact_path.read_text(encoding="utf-8")
-    assert "tag: core-mvp-20260319T170333Z-happy" in artifact_content
-    assert "scenario: happy-path" in artifact_content
+    assert "tag: core-mvp-20260319T173841Z-happy" in artifact_content
+    assert "scenario: happy" in artifact_content
+
+
+def test_happy_path_marker_artifact_exists_with_expected_tag_and_scenario():
+    artifact_path = appointment_handlers.HAPPY_PATH_ARTIFACT_PATH
+
+    assert artifact_path.exists()
+    artifact_content = artifact_path.read_text(encoding="utf-8")
+    assert f"tag: {appointment_handlers.HAPPY_PATH_ARTIFACT_TAG}" in artifact_content
+    assert (
+        f"scenario: {appointment_handlers.HAPPY_PATH_ARTIFACT_SCENARIO}"
+        in artifact_content
+    )


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Linked Linear Ticket
Fixes BER-97
https://linear.app/baek/issue/BER-97/add-run-specific-happy-path-artifact-and-test-coverage-for-core-mvp

## Instruction
Implement the approved Berry ticket: Add Run-Specific Happy-Path Artifact and Test Coverage for Core MVP Appointment Workflow.
Repository: https://github.com/bryanbaek/pypy
Base branch: main

Approved ticket description:
## Summary
Extend the existing appointment workflow in the sandbox repository to generate a run-specific artifact emitting a fresh diff for each run. Add a marker file at `sandbox/appointment/e2e/core-mvp-20260319T173841Z-happy.md` containing the tag `core-mvp-20260319T173841Z-happy` and the scenario `happy`. Update or add test coverage in `tests/test_sandbox_appointment_workflow.py` or a new test file `tests/test_sandbox_appointment_core_mvp_20260319T173841Z_happy.py` to verify that the happy-path workflow produces this tagged artifact. Maintain the existing repository, gateway, controller, and handler flow, applying the minimum necessary changes.

## Scope
- Modify the sandbox appointment workflow to include a run-specific artifact for the happy path.
- Add the marker file with the exact tag and scenario inside `sandbox/appointment/e2e`.
- Implement or update tests asserting presence of the tagged artifact.

## Acceptance Criteria
- The appointment workflow outputs a fresh, run-specific artifact on each execution.
- The marker file `core-mvp-20260319T173841Z-happy.md` exists in `sandbox/appointment/e2e` with correct tag and scenario contents.
- Tests pass verifying the artifact presence and correctness without disrupting existing flows.
- No modifications beyond minimal necessary changes to repository/gateway/controller/handler.

## Helpful Files
- `sandbox/appointment/e2e/core-mvp-20260319T170333Z-happy.md` (reference example marker file)
- `tests/test_sandbox_appointment_workflow.py`
- `sandbox/appointment/controller.py`
- `sandbox/appointment/__init__.py`

## Out of Scope
- Changes to main appointment business logic beyond artifact tagging.
- Modifications to unrelated workflows or endpoints.

## Codex Output
### Initial Draft
> Implemented BER-97 with a minimal diff focused on artifact tagging and coverage.
>
> **Files changed**
> - Updated artifact tag/scenario constants in [sandbox/appointment/handlers.py](/job/repo/sandbox/appointment/handlers.py)
> - Added new marker artifact file [sandbox/appointment/e2e/core-mvp-20260319T173841Z-happy.md](/job/repo/sandbox/appointment/e2e/core-mvp-20260319T173841Z-happy.md)
> - Updated a...

## Validation
- `just lint`: passed
- `just test`: passed

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.venv`