### PR TITLE
BER-98: Add run-specific artifact and happy-path marker for core-mvp-20260319T195344Z in sandbox appointment workflow

### DIFF
--- a/sandbox/appointment/e2e/core-mvp-20260319T195344Z-happy.md
+++ b/sandbox/appointment/e2e/core-mvp-20260319T195344Z-happy.md
@@ -1,0 +1,4 @@
+# Core MVP Happy-Path Verification Artifact
+
+tag: core-mvp-20260319T195344Z-happy
+scenario: happy

--- a/sandbox/appointment/handlers.py
+++ b/sandbox/appointment/handlers.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Protocol
 
-HAPPY_PATH_ARTIFACT_TAG = "core-mvp-20260319T173841Z-happy"
+HAPPY_PATH_ARTIFACT_TAG = "core-mvp-20260319T195344Z-happy"
 HAPPY_PATH_ARTIFACT_SCENARIO = "happy"
 HAPPY_PATH_ARTIFACT_PATH = (
     Path(__file__).resolve().parent

--- a/tests/test_sandbox_appointment_workflow.py
+++ b/tests/test_sandbox_appointment_workflow.py
@@ -637,7 +637,7 @@ def test_handler_controller_gateway_repository_rejects_overlapping_window():
 
 
 def test_handler_happy_path_writes_core_mvp_verification_artifact(tmp_path, monkeypatch):
-    artifact_path = tmp_path / "core-mvp-20260319T173841Z-happy.md"
+    artifact_path = tmp_path / "core-mvp-20260319T195344Z-happy.md"
     monkeypatch.setattr(
         appointment_handlers, "HAPPY_PATH_ARTIFACT_PATH", artifact_path
     )
@@ -659,7 +659,7 @@ def test_handler_happy_path_writes_core_mvp_verification_artifact(tmp_path, monk
     assert created["status"] == "ok"
     assert artifact_path.exists()
     artifact_content = artifact_path.read_text(encoding="utf-8")
-    assert "tag: core-mvp-20260319T173841Z-happy" in artifact_content
+    assert "tag: core-mvp-20260319T195344Z-happy" in artifact_content
     assert "scenario: happy" in artifact_content
 
 


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Linked Linear Ticket
Fixes BER-98
https://linear.app/baek/issue/BER-98/add-run-specific-artifact-and-happy-path-marker-for-core-mvp

## Instruction
Implement the approved Berry ticket: Add run-specific artifact and happy-path marker for core-mvp-20260319T195344Z in sandbox appointment workflow.
Repository: https://github.com/bryanbaek/pypy
Base branch: main

Approved ticket description:
# Summary
Extend the sandbox appointment workflow to include a run-specific artifact ensuring fresh diffs on each run. Add a marker file with tag `core-mvp-20260319T195344Z-happy` and scenario `happy` at `sandbox/appointment/e2e/core-mvp-20260319T195344Z-happy.md`. Update or create test coverage to assert the presence of this tagged artifact, verifying the appointment happy-path flow.

# Scope
- Modify the appointment workflow in `sandbox/appointment` to generate a run-specific artifact.
- Add a new marker file at `sandbox/appointment/e2e/core-mvp-20260319T195344Z-happy.md` containing the exact tag and scenario.
- Update existing test `tests/test_sandbox_appointment_workflow.py` or create a new test file `tests/test_sandbox_appointment_core_mvp_20260319T195344Z_happy.py` to assert that the artifact and marker are generated correctly.
- Preserve the existing repository/gateway/controller/handler architecture without major changes.

# Acceptance Criteria
- A run-specific artifact is produced on each workflow run in the sandbox appointment process.
- The marker file at `sandbox/appointment/e2e/core-mvp-20260319T195344Z-happy.md` exists and contains the correct tag and scenario strings.
- Automated tests verify the presence and correctness of the artifact and marker file.
- No regressions or changes to the current flow logic outside of the minimal required changes for this extension.

# Helpful Files
- `sandbox/appointment/controller.py`
- `sandbox/appointment/e2e/core-mvp-20260319T170333Z-happy.md` (example existing happy-path marker)
- `tests/test_sandbox_appointment_workflow.py`

# Out of Scope
- Changes to appointment business logic, validation, or overlap conflict detection.
- Modifications to repository, gateway, or handler architecture beyond minimal additions.
- Changes outside the sandbox appointment workflow.

---

## Codex Output
### Initial Draft
> Implemented `BER-98` with the smallest targeted diff.
>
> **Files changed**
> - [sandbox/appointment/handlers.py](/job/repo/sandbox/appointment/handlers.py)
>   - Updated `HAPPY_PATH_ARTIFACT_TAG` from `core-mvp-20260319T173841Z-happy` to `core-mvp-20260319T195344Z-happy`.
>   - This updates the run-specific artifact path to `sandbox/appointment/e2e/core-mvp-20260319T195344Z-happy.md` via existing path ...

## Validation
- `just lint`: passed
- `just test`: passed

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.venv`