### PR TITLE
BER-100: Add tagged happy-path sandbox artifact and assertion for core-mvp-20260319T233431Z-happy

### DIFF
--- a/sandbox/appointment/e2e/core-mvp-20260319T233431Z-happy.md
+++ b/sandbox/appointment/e2e/core-mvp-20260319T233431Z-happy.md
@@ -1,0 +1,4 @@
+# Core MVP Happy-Path Verification Artifact
+
+tag: core-mvp-20260319T233431Z-happy
+scenario: happy

--- a/tests/test_sandbox_appointment_workflow.py
+++ b/tests/test_sandbox_appointment_workflow.py
@@ -689,3 +689,18 @@ def test_run_specific_happy_path_marker_artifact_exists_with_expected_tag_and_sc
     artifact_content = artifact_path.read_text(encoding="utf-8")
     assert "tag: core-mvp-20260319T213245Z-happy" in artifact_content
     assert "scenario: happy" in artifact_content
+
+
+def test_tagged_happy_path_marker_artifact_exists_with_expected_tag_and_scenario():
+    artifact_path = (
+        Path(__file__).resolve().parents[1]
+        / "sandbox"
+        / "appointment"
+        / "e2e"
+        / "core-mvp-20260319T233431Z-happy.md"
+    )
+
+    assert artifact_path.exists()
+    artifact_content = artifact_path.read_text(encoding="utf-8")
+    assert "tag: core-mvp-20260319T233431Z-happy" in artifact_content
+    assert "scenario: happy" in artifact_content


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Linked Linear Ticket
Fixes BER-100
https://linear.app/baek/issue/BER-100/add-tagged-happy-path-sandbox-artifact-and-assertion-for-core-mvp

## Instruction
Implement the approved Berry ticket: Add tagged happy-path sandbox artifact and assertion for core-mvp-20260319T233431Z-happy.
Repository: https://github.com/bryanbaek/pypy
Base branch: main

Approved ticket description:
## Summary
Add a run-specific sandbox appointment artifact for the `core-mvp-20260319T233431Z-happy` verification pass and extend the sandbox happy-path test coverage so CI asserts that the tagged artifact exists with the expected contents. This should be a minimal follow-up that preserves the existing backend appointment flow across repository/gateway/controller/handler layers.

## Scope
- Create `sandbox/appointment/e2e/core-mvp-20260319T233431Z-happy.md`.
- Ensure the file contains the exact tag `core-mvp-20260319T233431Z-happy` and the scenario `happy`.
- Update `tests/test_sandbox_appointment_workflow.py` or add a narrowly scoped new sandbox test file to assert the artifact is present and matches the expected tagged happy-path marker.
- Keep the existing appointment workflow behavior unchanged outside of this tagged verification artifact.
- Ensure the change remains compatible with the current Python test workflow used by repository CI.

## Acceptance Criteria
- `sandbox/appointment/e2e/core-mvp-20260319T233431Z-happy.md` exists in the repo.
- The marker file includes the exact literal string `core-mvp-20260319T233431Z-happy`.
- The marker file includes the exact literal string `happy` as the scenario.
- Sandbox appointment test coverage fails if the tagged artifact is missing or its required marker content changes.
- Existing appointment workflow tests continue to validate the current happy-path flow without requiring changes to `src/backend` repository, gateway, controller, or handler behavior.
- The implementation is the smallest practical change and passes the existing Python test workflow.

## Helpful Files
- `sandbox/appointment/e2e/core-mvp-20260319T170333Z-happy.md`
- `sandbox/appointment/controller.py`
- `tests/test_sandbox_appointment_workflow.py`
- `tests/test_backend_appointment_workflow.py`
- `tests/test_core_workflow.py`
- `README.md`
- `.github/workflows/python-app.yml`

## Out of Scope
- Refactoring the appointment repository/gateway/controller/handler flow in `src/backend`.
- Changing business-hour, normalization, or overlap-validation logic described in `README.md`.
- Adding new production endpoints, persistence behavior, or sandbox workflow variants beyond this tagged happy-path artifact.
- Broader CI workflow changes outside what is required for the existing tests to detect the new artifact.

## Codex Output
### Initial Draft
> Added the tagged sandbox artifact at [sandbox/appointment/e2e/core-mvp-20260319T233431Z-happy.md](/job/repo/sandbox/appointment/e2e/core-mvp-20260319T233431Z-happy.md) with the required `tag: core-mvp-20260319T233431Z-happy` and `scenario: happy` markers. I also extended [tests/test_sandbox_appointment_workflow.py](/job/repo/tests/test_sandbox_appointment_workflow.py) with a narrowly scoped ass...

## Validation
- `just lint`: passed
- `just test`: passed

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.venv`