### PR TITLE
BER-101: Replace appointment-specific sample workflow with generic document CRUD template and README updates

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -2,4 +2,4 @@ lint:
   test -f README.md
 
 test:
-  test -f tests/test_backend_appointment_workflow.py
+  test -f tests/test_backend_document_workflow.py

--- a/README.md
+++ b/README.md
@@ -1,181 +1,62 @@
-# Business Booking & Ecommerce Platform
+# FastAPI Template
 
-A business booking and ecommerce platform with AI integration capabilities for appointment scheduling, product management, and order tracking.
+This repository is a reusable Python/FastAPI template with a small document CRUD sample. The default example is intentionally domain-neutral so you can copy the layer boundaries without inheriting business-specific rules.
 
-## Overview
+## Sample Layout
 
-### 1. Core
-The core directory contains fundamental application code:
+The template demonstrates a single document flow across the backend layers in `src/backend`:
 
-- **Configuration**: Settings, constants, and configuration parameters used throughout the application.
-- **Utilities**: Helper functions, decorators, middleware, and other utility classes or functions.
-- **Custom Exceptions**: Custom exception classes that are used throughout the application.
-- **Workflow Validation**: Core appointment happy-path validation before persistence, including title normalization (trim + whitespace collapsing), business-hour enforcement (appointments must stay within `09:00` through `17:00` on the same day), and overlap conflict detection.
+- `src/backend/core`: input normalization for the sample document payload.
+- `src/backend/repository`: persistence helpers for `get`, `write` (create-or-update), and `delete`.
+- `src/backend/gateway`: connection-aware delegation into the repository layer.
+- `src/backend/controller`: workflow orchestration that applies core normalization before writes.
+- `src/backend/handlers`: request-payload translation plus a small sample artifact written during a successful document write.
+- `src/backend/db/postgres.py`: minimal database wrapper helpers for the same document sample.
 
-### 2. Routes
-The routes directory defines HTTP routes (endpoints) for the FastAPI application:
+The sandbox mirror in `sandbox/document` gives contributors a generic example slice to copy or adapt without referencing any business domain.
 
-- **Chat Routes**: Endpoints for AI chat functionality with various models (OpenAI, Google, Groq).
+## Sample Operations
 
-### 3. Services
-The services directory contains business logic:
+The default sample supports three basic operations:
 
-- **Database Operations**: CRUD operations and other database-related logic.
-- **AI Services**: Integration with OpenAI, Google Gemini, and Groq AI models.
+- `get_document(document_id)`
+- `write_document(document_id, title, content)`
+- `delete_document(document_id)`
 
-### 4. Backend Workflow Layers
-The `src/backend` package is the source of truth for backend workflow orchestration:
+`write_document` uses create-or-update semantics so the same sample covers both initial creation and later replacement.
 
-- **Repository** (`src/backend/repository`): Persistence and overlap query operations.
-- **Gateway** (`src/backend/gateway`): Abstraction over repository and connection access.
-- **Controller** (`src/backend/controller`): Workflow orchestration using core validation (title normalization, business-hour checks, conflict rejection).
-- **Handlers** (`src/backend/handlers`): Request-payload translation, response shaping, and lightweight appointment flow examples.
+## Run
 
-## Setup
+Install dependencies with your preferred toolchain. If you use `uv`:
 
-### Install dependencies
 ```bash
-# Install uv if you haven't already
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Install project dependencies
 uv sync
-```
-
-## How to Run
-
-This project uses [Just](https://github.com/casey/just) as a command runner. Just provides a convenient way to run common development tasks.
-
-### Quick Start
-```bash
-# Setup the project
-just setup
-
-# Start development server
-just dev
-
-# Run tests
-just test
-```
-
-### Available Commands
-
-#### Setup and Development
-```bash
-just setup        # Install dependencies
-just dev          # Start development server with hot reload
-just run          # Start production server
-```
-
-#### Testing
-```bash
-just test         # Run all tests
-```
-
-#### Code Quality
-```bash
-just lint         # Run linters
-just format       # Format code with ruff
-just typecheck    # Run mypy type checker
-```
-
-#### Docker (Single Container)
-```bash
-just docker-build # Build Docker image
-just docker-run   # Run in Docker container
-just docker-stop  # Stop Docker container
-just docker-logs  # View Docker container logs
-just docker-clean # Clean up Docker resources
-```
-
-#### Docker Compose (Full Stack)
-```bash
-just setup-env    # Create .env file from example
-just compose-up   # Start all services (app, database, redis, chromadb)
-just compose-down # Stop all services
-just compose-logs # View logs from all services
-just compose-status # Show status of all services
-```
-
-#### Maintenance
-```bash
-just clean        # Clean generated files and caches
-just update       # Update dependencies
-just install-hooks# Install pre-commit hooks
-just info         # Show project information
-just help         # Show detailed help
-```
-
-### Manual Commands (if you prefer not to use Just)
-
-#### Main API Server
-```bash
 uv run uvicorn src.backend.web.rest.main:app --reload
 ```
 
+The included FastAPI app starts from `src/backend/web/rest/main.py`.
 
-#### Run Tests
+## Verify
+
+The default sample is exercised by the repository test suite:
+
 ```bash
 uv run pytest
 ```
 
-## Features
+The main files to inspect while adapting the template are:
 
-- **AI Integration**: Support for OpenAI GPT-4o, Google Gemini Pro/Lite, and Groq models
-- **RESTful API**: FastAPI-based REST API with automatic documentation
-- **Async Support**: Full async/await support for better performance
-- **Type Safety**: Comprehensive type hints and validation with Pydantic
-- **Database Support**: PostgreSQL with business schema and indexing
-- **Caching**: Redis for session management and caching
-- **Vector Storage**: ChromaDB for embeddings and semantic search
-- **Containerization**: Full Docker Compose setup for easy deployment
+- `src/backend/core/__init__.py`
+- `src/backend/controller/__init__.py`
+- `src/backend/repository/__init__.py`
+- `src/backend/gateway/__init__.py`
+- `src/backend/handlers/__init__.py`
+- `sandbox/document/__init__.py`
+- `tests/test_core_document_workflow.py`
+- `tests/test_backend_document_workflow.py`
+- `tests/test_sandbox_document_workflow.py`
 
-## Docker Compose Setup
+## Notes
 
-The application includes a comprehensive Docker Compose configuration with the following services:
-
-### Services Included
-
-- **booking-app**: Main FastAPI application for business operations
-- **postgres**: PostgreSQL database with business schema and sample data
-- **redis**: Redis for caching and session storage
-- **chromadb**: ChromaDB for vector storage and embeddings
-- **nginx**: Reverse proxy with load balancing (production profile)
-
-### Quick Start with Docker Compose
-
-1. **Setup environment**:
-   ```bash
-   just setup-env  # Creates .env file from env.example
-   # Edit .env file with your API keys
-   ```
-
-2. **Start all services**:
-   ```bash
-   just compose-up
-   ```
-
-3. **View logs**:
-   ```bash
-   just compose-logs
-   ```
-
-4. **Stop services**:
-   ```bash
-   just compose-down
-   ```
-
-### Available URLs
-
-- **Main API**: http://localhost:8000
-- **API Documentation**: http://localhost:8000/docs
-- **PostgreSQL**: localhost:5432
-- **Redis**: localhost:6379
-- **ChromaDB**: http://localhost:8001
-- **Nginx** (production): http://localhost
-
-### Data Persistence
-
-All data is persisted using Docker volumes:
-- `postgres_data`: Database data
-- `redis_data`: Redis data
+- The sample is deliberately small and not production-ready.
+- The repository still includes infrastructure scaffolding such as Docker, GitHub Actions, and FastAPI app wiring so you can build on top of the template.

--- a/sandbox/document/__init__.py
+++ b/sandbox/document/__init__.py
@@ -1,0 +1,23 @@
+"""Document workflow slice with repository, gateway, controller, and handlers."""
+
+from sandbox.document.controller import DocumentController
+from sandbox.document.gateway import DocumentGateway
+from sandbox.document.handlers import (
+    DOCUMENT_SAMPLE_ARTIFACT_PATH,
+    DOCUMENT_SAMPLE_ARTIFACT_SCENARIO,
+    DOCUMENT_SAMPLE_ARTIFACT_TAG,
+    handle_delete_document,
+    handle_get_document,
+    handle_write_document,
+)
+
+__all__ = [
+    "DOCUMENT_SAMPLE_ARTIFACT_PATH",
+    "DOCUMENT_SAMPLE_ARTIFACT_SCENARIO",
+    "DOCUMENT_SAMPLE_ARTIFACT_TAG",
+    "DocumentController",
+    "DocumentGateway",
+    "handle_delete_document",
+    "handle_get_document",
+    "handle_write_document",
+]

--- a/sandbox/document/controller.py
+++ b/sandbox/document/controller.py
@@ -1,0 +1,5 @@
+"""Sandbox re-export of the template document controller."""
+
+from src.backend.controller import DocumentController, DocumentGatewayContract
+
+__all__ = ["DocumentController", "DocumentGatewayContract"]

--- a/sandbox/document/e2e/sandbox-document-crud-template.md
+++ b/sandbox/document/e2e/sandbox-document-crud-template.md
@@ -1,0 +1,4 @@
+# Sandbox Document CRUD Sample Artifact
+
+tag: sandbox-document-crud-template
+scenario: write-document

--- a/sandbox/document/gateway.py
+++ b/sandbox/document/gateway.py
@@ -1,0 +1,5 @@
+"""Sandbox re-export of the template document gateway."""
+
+from src.backend.gateway import DocumentGateway, DocumentRepository
+
+__all__ = ["DocumentGateway", "DocumentRepository"]

--- a/sandbox/document/handlers.py
+++ b/sandbox/document/handlers.py
@@ -1,9 +1,9 @@
-"""Handler layer for translating payloads to document controller operations."""
+"""Sandbox handler layer for the template document sample."""
 
 from pathlib import Path
 from typing import Protocol
 
-DOCUMENT_SAMPLE_ARTIFACT_TAG = "document-crud-template"
+DOCUMENT_SAMPLE_ARTIFACT_TAG = "sandbox-document-crud-template"
 DOCUMENT_SAMPLE_ARTIFACT_SCENARIO = "write-document"
 DOCUMENT_SAMPLE_ARTIFACT_PATH = Path(__file__).resolve().parent / "e2e" / (
     f"{DOCUMENT_SAMPLE_ARTIFACT_TAG}.md"
@@ -11,7 +11,7 @@ DOCUMENT_SAMPLE_ARTIFACT_PATH = Path(__file__).resolve().parent / "e2e" / (
 
 
 class DocumentControllerContract(Protocol):
-    """Controller contract used by document handlers."""
+    """Controller contract used by sandbox document handlers."""
 
     async def get_document(self, document_id: str) -> dict | None: ...
 
@@ -21,11 +21,10 @@ class DocumentControllerContract(Protocol):
 
 
 def _write_document_sample_artifact() -> None:
-    """Write a marker artifact for the backend document sample flow."""
     DOCUMENT_SAMPLE_ARTIFACT_PATH.parent.mkdir(parents=True, exist_ok=True)
     DOCUMENT_SAMPLE_ARTIFACT_PATH.write_text(
         (
-            "# Document CRUD Sample Artifact\n\n"
+            "# Sandbox Document CRUD Sample Artifact\n\n"
             f"tag: {DOCUMENT_SAMPLE_ARTIFACT_TAG}\n"
             f"scenario: {DOCUMENT_SAMPLE_ARTIFACT_SCENARIO}\n"
         ),
@@ -36,7 +35,6 @@ def _write_document_sample_artifact() -> None:
 async def handle_write_document(
     controller: DocumentControllerContract, payload: dict
 ) -> dict:
-    """Handle write-document input payloads."""
     try:
         document = await controller.write_document(
             document_id=payload["id"],
@@ -53,7 +51,6 @@ async def handle_write_document(
 async def handle_get_document(
     controller: DocumentControllerContract, document_id: str
 ) -> dict:
-    """Handle get-document requests."""
     document = await controller.get_document(document_id)
     if document is None:
         return {"status": "error", "error": "document not found"}
@@ -63,7 +60,6 @@ async def handle_get_document(
 async def handle_delete_document(
     controller: DocumentControllerContract, document_id: str
 ) -> dict:
-    """Handle delete-document requests."""
     try:
         deletion = await controller.delete_document(document_id)
     except ValueError as exc:

--- a/sandbox/document/repository.py
+++ b/sandbox/document/repository.py
@@ -1,0 +1,10 @@
+"""Sandbox re-export of the template document repository."""
+
+from src.backend.repository import (
+    DocumentConnection,
+    delete_document,
+    get_document,
+    write_document,
+)
+
+__all__ = ["DocumentConnection", "delete_document", "get_document", "write_document"]

--- a/src/backend/controller/__init__.py
+++ b/src/backend/controller/__init__.py
@@ -1,112 +1,47 @@
-"""Controller layer coordinating appointment workflow validation and actions."""
+"""Controller layer coordinating the template document workflow."""
 
-from datetime import datetime
 from typing import Protocol
 
-from src.backend.core import validate_appointment_window
+from src.backend.core import prepare_document_record
 
 
-class AppointmentGatewayContract(Protocol):
-    """Gateway contract used by appointment controller orchestration."""
+class DocumentGatewayContract(Protocol):
+    """Gateway contract used by document controller orchestration."""
 
-    async def has_conflict(
-        self,
-        start_time: datetime,
-        end_time: datetime,
-        exclude_appointment_id: int | None = None,
-    ) -> bool: ...
+    async def get_document(self, document_id: str) -> dict | None: ...
 
-    async def create_appointment(
-        self, title: str, start_time: datetime, end_time: datetime
-    ) -> dict: ...
+    async def write_document(self, document_id: str, title: str, content: str) -> dict: ...
 
-    async def get_appointment(self, appointment_id: int) -> dict | None: ...
-
-    async def get_appointments(self) -> list[dict]: ...
-
-    async def update_appointment(
-        self,
-        appointment_id: int,
-        title: str,
-        start_time: datetime,
-        end_time: datetime,
-    ) -> dict | None: ...
-
-    async def delete_appointment(self, appointment_id: int) -> None: ...
+    async def delete_document(self, document_id: str) -> None: ...
 
 
-class AppointmentController:
-    """Application workflow service for appointment use cases."""
+class DocumentController:
+    """Application workflow service for the template document sample."""
 
-    def __init__(self, gateway: AppointmentGatewayContract) -> None:
+    def __init__(self, gateway: DocumentGatewayContract) -> None:
         self._gateway = gateway
 
-    async def create_appointment(
-        self, title: str, start_time: datetime, end_time: datetime
-    ) -> dict:
-        """Validate and create an appointment when no conflict exists."""
-        window = validate_appointment_window(title, start_time, end_time)
-
-        if await self._gateway.has_conflict(window.start_time, window.end_time):
-            raise ValueError("appointment conflicts with an existing booking")
-
-        return await self._gateway.create_appointment(
-            window.title,
-            window.start_time,
-            window.end_time,
+    async def write_document(self, document_id: str, title: str, content: str) -> dict:
+        """Validate and persist a document with create-or-update behavior."""
+        record = prepare_document_record(document_id, title, content)
+        return await self._gateway.write_document(
+            record.id,
+            record.title,
+            record.content,
         )
 
-    async def get_appointment(self, appointment_id: int) -> dict | None:
-        """Fetch a single appointment by id."""
-        return await self._gateway.get_appointment(appointment_id)
+    async def get_document(self, document_id: str) -> dict | None:
+        """Fetch a single document by id."""
+        return await self._gateway.get_document(document_id)
 
-    async def get_appointments(self) -> list[dict]:
-        """List all appointments."""
-        return await self._gateway.get_appointments()
-
-    async def update_appointment(
-        self,
-        appointment_id: int,
-        title: str | None = None,
-        start_time: datetime | None = None,
-        end_time: datetime | None = None,
-    ) -> dict:
-        """Update an appointment with validation and conflict checks."""
-        existing = await self._gateway.get_appointment(appointment_id)
+    async def delete_document(self, document_id: str) -> dict:
+        """Delete a document and return a normalized response payload."""
+        existing = await self._gateway.get_document(document_id)
         if existing is None:
-            raise ValueError("appointment not found")
+            raise ValueError("document not found")
 
-        window = validate_appointment_window(
-            title=existing["title"] if title is None else title,
-            start_time=existing["start_time"] if start_time is None else start_time,
-            end_time=existing["end_time"] if end_time is None else end_time,
-        )
-
-        if await self._gateway.has_conflict(
-            window.start_time,
-            window.end_time,
-            exclude_appointment_id=appointment_id,
-        ):
-            raise ValueError("appointment conflicts with an existing booking")
-
-        appointment = await self._gateway.update_appointment(
-            appointment_id,
-            window.title,
-            window.start_time,
-            window.end_time,
-        )
-        if appointment is None:
-            raise ValueError("appointment not found")
-        return appointment
-
-    async def delete_appointment(self, appointment_id: int) -> dict:
-        """Delete an appointment and return a normalized response payload."""
-        existing = await self._gateway.get_appointment(appointment_id)
-        if existing is None:
-            raise ValueError("appointment not found")
-
-        await self._gateway.delete_appointment(appointment_id)
-        return {"deleted_id": appointment_id}
+        await self._gateway.delete_document(document_id)
+        return {"deleted_id": document_id}
 
 
-__all__ = ["AppointmentController", "AppointmentGatewayContract"]
+__all__ = ["DocumentController", "DocumentGatewayContract"]

--- a/src/backend/core/__init__.py
+++ b/src/backend/core/__init__.py
@@ -1,94 +1,67 @@
+"""Core helpers for the template document CRUD sample."""
+
 from dataclasses import dataclass
-from datetime import datetime, time
+from typing import Protocol
 
 
 @dataclass(frozen=True, slots=True)
-class AppointmentWindow:
+class DocumentRecord:
+    """Normalized document payload used across the sample layers."""
+
+    id: str
     title: str
-    start_time: datetime
-    end_time: datetime
+    content: str
 
 
-BUSINESS_HOUR_START = time(9, 0)
-BUSINESS_HOUR_END = time(17, 0)
+class DocumentWriteConnection(Protocol):
+    """Minimal async database interface required by core write helpers."""
+
+    async def fetchrow(self, query: str, *args: object) -> dict | None: ...
 
 
-def normalize_appointment_title(title: str) -> str:
-    """Trim and collapse all whitespace in appointment titles."""
-    if not isinstance(title, str):
-        raise ValueError("title must be a string")
-    return " ".join(title.split())
+def _normalize_required_text(field: str, value: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field} must not be empty")
+    return normalized
 
 
-def validate_appointment_time_window(start_time: datetime, end_time: datetime) -> None:
-    """Validate chronological order, same-day window, and 09:00-17:00 bounds."""
-    if end_time <= start_time:
-        raise ValueError("end_time must be after start_time")
-
-    if start_time.date() != end_time.date():
-        raise ValueError("appointment must start and end on the same day")
-
-    start_tod = start_time.time()
-    end_tod = end_time.time()
-    if start_tod < BUSINESS_HOUR_START or end_tod > BUSINESS_HOUR_END:
-        raise ValueError("appointment must be within business hours (09:00-17:00)")
-
-
-def validate_appointment_window(
-    title: str, start_time: datetime, end_time: datetime
-) -> AppointmentWindow:
-    normalized_title = normalize_appointment_title(title)
-    if not normalized_title:
-        raise ValueError("title must not be empty")
-
-    validate_appointment_time_window(start_time, end_time)
-
-    return AppointmentWindow(
-        title=normalized_title, start_time=start_time, end_time=end_time
+def prepare_document_record(document_id: str, title: str, content: str) -> DocumentRecord:
+    """Normalize the sample document payload before persistence."""
+    return DocumentRecord(
+        id=_normalize_required_text("document_id", document_id),
+        title=_normalize_required_text("title", " ".join(title.split())),
+        content=_normalize_required_text("content", content),
     )
 
 
-async def has_appointment_conflict(
-    conn, start_time: datetime, end_time: datetime
-) -> bool:
-    """Return True when an existing appointment overlaps the requested window."""
-    conflicting = await conn.fetch(
+def _record_to_dict(record: DocumentRecord) -> dict:
+    return {"id": record.id, "title": record.title, "content": record.content}
+
+
+async def write_document_sample(
+    conn: DocumentWriteConnection, document_id: str, title: str, content: str
+) -> DocumentRecord | dict:
+    """Normalize and write the template document sample with create-or-update semantics."""
+    record = prepare_document_record(document_id, title, content)
+    row = await conn.fetchrow(
         """
-        SELECT 1
-        FROM appointments
-        WHERE start_time < $2
-          AND end_time > $1
-        LIMIT 1
+        INSERT INTO documents (id, title, content)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (id)
+        DO UPDATE SET title = EXCLUDED.title, content = EXCLUDED.content
+        RETURNING id, title, content
         """,
-        start_time,
-        end_time,
+        record.id,
+        record.title,
+        record.content,
     )
-    return bool(conflicting)
+    if row is None:
+        return _record_to_dict(record)
+    return DocumentRecord(id=row["id"], title=row["title"], content=row["content"])
 
 
-async def run_appointment_happy_path(
-    conn, title: str, start_time: datetime, end_time: datetime
-) -> AppointmentWindow:
-    window = validate_appointment_window(title, start_time, end_time)
-    if await has_appointment_conflict(conn, window.start_time, window.end_time):
-        raise ValueError("appointment conflicts with an existing booking")
-
-    await conn.execute(
-        "INSERT INTO appointments (title, start_time, end_time) VALUES ($1, $2, $3)",
-        window.title,
-        window.start_time,
-        window.end_time,
-    )
-    return window
-
-
-__all__ = [
-    "AppointmentWindow",
-    "BUSINESS_HOUR_END",
-    "BUSINESS_HOUR_START",
-    "has_appointment_conflict",
-    "normalize_appointment_title",
-    "run_appointment_happy_path",
-    "validate_appointment_time_window",
-    "validate_appointment_window",
-]
+__all__ = ["DocumentRecord", "DocumentWriteConnection", "prepare_document_record", "write_document_sample"]

--- a/src/backend/db/postgres.py
+++ b/src/backend/db/postgres.py
@@ -1,39 +1,25 @@
 import asyncpg  # type: ignore
 
-from src.backend.core import run_appointment_happy_path
+from src.backend.core import write_document_sample
 
 
-async def create_appointment(conn, title, start_time, end_time):
-    return await run_appointment_happy_path(conn, title, start_time, end_time)
+async def write_document(conn, document_id, title, content):
+    return await write_document_sample(conn, document_id, title, content)
 
 
-async def get_appointments(conn):
-    return await conn.fetch("SELECT * FROM appointments")
+async def get_document(conn, document_id):
+    return await conn.fetchrow(
+        """
+        SELECT id, title, content
+        FROM documents
+        WHERE id = $1
+        """,
+        document_id,
+    )
 
 
-async def update_appointment(
-    conn, appointment_id, title=None, start_time=None, end_time=None
-):
-    if title:
-        await conn.execute(
-            "UPDATE appointments SET title = $1 WHERE id = $2", title, appointment_id
-        )
-    if start_time:
-        await conn.execute(
-            "UPDATE appointments SET start_time = $1 WHERE id = $2",
-            start_time,
-            appointment_id,
-        )
-    if end_time:
-        await conn.execute(
-            "UPDATE appointments SET end_time = $1 WHERE id = $2",
-            end_time,
-            appointment_id,
-        )
-
-
-async def delete_appointment(conn, appointment_id):
-    await conn.execute("DELETE FROM appointments WHERE id = $1", appointment_id)
+async def delete_document(conn, document_id):
+    await conn.execute("DELETE FROM documents WHERE id = $1", document_id)
 
 
 async def connect_to_db():

--- a/src/backend/gateway/__init__.py
+++ b/src/backend/gateway/__init__.py
@@ -1,107 +1,52 @@
-"""Gateway layer for backend appointment workflows."""
+"""Gateway layer for the template document workflow."""
 
-from datetime import datetime
 from typing import Protocol
 
 from src.backend import repository as default_repository
-from src.backend.repository import AppointmentConnection
+from src.backend.repository import DocumentConnection
 
 
-class AppointmentRepository(Protocol):
-    """Repository contract used by the appointment gateway."""
+class DocumentRepository(Protocol):
+    """Repository contract used by the document gateway."""
 
-    async def has_conflict(
-        self,
-        conn: AppointmentConnection,
-        start_time: datetime,
-        end_time: datetime,
-        exclude_appointment_id: int | None = None,
-    ) -> bool: ...
+    async def get_document(
+        self, conn: DocumentConnection, document_id: str
+    ) -> dict | None: ...
 
-    async def create_appointment(
-        self,
-        conn: AppointmentConnection,
-        title: str,
-        start_time: datetime,
-        end_time: datetime,
+    async def write_document(
+        self, conn: DocumentConnection, document_id: str, title: str, content: str
     ) -> dict: ...
 
-    async def get_appointment(
-        self, conn: AppointmentConnection, appointment_id: int
-    ) -> dict | None: ...
-
-    async def get_appointments(self, conn: AppointmentConnection) -> list[dict]: ...
-
-    async def update_appointment(
-        self,
-        conn: AppointmentConnection,
-        appointment_id: int,
-        title: str,
-        start_time: datetime,
-        end_time: datetime,
-    ) -> dict | None: ...
-
-    async def delete_appointment(
-        self, conn: AppointmentConnection, appointment_id: int
-    ) -> None: ...
+    async def delete_document(self, conn: DocumentConnection, document_id: str) -> None: ...
 
 
-class AppointmentGateway:
-    """Abstraction over repository access for appointment operations."""
+class DocumentGateway:
+    """Abstraction over repository access for document operations."""
 
     def __init__(
         self,
-        conn: AppointmentConnection,
-        repository: AppointmentRepository = default_repository,
+        conn: DocumentConnection,
+        repository: DocumentRepository = default_repository,
     ) -> None:
         self._conn = conn
         self._repository = repository
 
-    async def has_conflict(
-        self,
-        start_time: datetime,
-        end_time: datetime,
-        exclude_appointment_id: int | None = None,
-    ) -> bool:
-        """Check whether a requested appointment window conflicts."""
-        return await self._repository.has_conflict(
+    async def get_document(self, document_id: str) -> dict | None:
+        """Get a single document by id."""
+        return await self._repository.get_document(self._conn, document_id)
+
+    async def write_document(self, document_id: str, title: str, content: str) -> dict:
+        """Create or update a document through the repository."""
+        return await self._repository.write_document(
             self._conn,
-            start_time,
-            end_time,
-            exclude_appointment_id=exclude_appointment_id,
+            document_id,
+            title,
+            content,
         )
 
-    async def create_appointment(
-        self, title: str, start_time: datetime, end_time: datetime
-    ) -> dict:
-        """Create an appointment through the repository."""
-        return await self._repository.create_appointment(
-            self._conn, title, start_time, end_time
-        )
-
-    async def get_appointment(self, appointment_id: int) -> dict | None:
-        """Get a single appointment by id."""
-        return await self._repository.get_appointment(self._conn, appointment_id)
-
-    async def get_appointments(self) -> list[dict]:
-        """List all appointments."""
-        return await self._repository.get_appointments(self._conn)
-
-    async def update_appointment(
-        self,
-        appointment_id: int,
-        title: str,
-        start_time: datetime,
-        end_time: datetime,
-    ) -> dict | None:
-        """Update an existing appointment by id."""
-        return await self._repository.update_appointment(
-            self._conn, appointment_id, title, start_time, end_time
-        )
-
-    async def delete_appointment(self, appointment_id: int) -> None:
-        """Delete an appointment by id."""
-        await self._repository.delete_appointment(self._conn, appointment_id)
+    async def delete_document(self, document_id: str) -> None:
+        """Delete a document by id."""
+        await self._repository.delete_document(self._conn, document_id)
 
 
-__all__ = ["AppointmentGateway", "AppointmentRepository"]
+__all__ = ["DocumentGateway", "DocumentRepository"]

--- a/src/backend/handlers/e2e/document-crud-template.md
+++ b/src/backend/handlers/e2e/document-crud-template.md
@@ -1,0 +1,4 @@
+# Document CRUD Sample Artifact
+
+tag: document-crud-template
+scenario: write-document

--- a/src/backend/repository/__init__.py
+++ b/src/backend/repository/__init__.py
@@ -1,148 +1,66 @@
-"""Repository layer for appointment persistence and conflict queries."""
+"""Repository layer for the template document sample."""
 
-from datetime import datetime
 from typing import Protocol
 
 
-class AppointmentConnection(Protocol):
+class DocumentConnection(Protocol):
     """Minimal async database interface required by repository functions."""
 
     async def execute(self, query: str, *args: object) -> object: ...
 
-    async def fetch(self, query: str, *args: object) -> list[object]: ...
-
     async def fetchrow(self, query: str, *args: object) -> dict | None: ...
 
 
-def _row_to_appointment(row: dict | None) -> dict | None:
-    """Convert a database row to an appointment dictionary payload."""
+def _row_to_document(row: dict | None) -> dict | None:
+    """Convert a database row to a document dictionary payload."""
     if row is None:
         return None
-    return {
-        "id": row["id"],
-        "title": row["title"],
-        "start_time": row["start_time"],
-        "end_time": row["end_time"],
-    }
+    return {"id": row["id"], "title": row["title"], "content": row["content"]}
 
 
-async def has_conflict(
-    conn: AppointmentConnection,
-    start_time: datetime,
-    end_time: datetime,
-    exclude_appointment_id: int | None = None,
-) -> bool:
-    """Return True when an appointment overlaps the requested window."""
-    if exclude_appointment_id is None:
-        conflicting = await conn.fetch(
-            """
-            SELECT 1
-            FROM appointments
-            WHERE start_time < $2
-              AND end_time > $1
-            LIMIT 1
-            """,
-            start_time,
-            end_time,
-        )
-    else:
-        conflicting = await conn.fetch(
-            """
-            SELECT 1
-            FROM appointments
-            WHERE start_time < $2
-              AND end_time > $1
-              AND id != $3
-            LIMIT 1
-            """,
-            start_time,
-            end_time,
-            exclude_appointment_id,
-        )
-    return bool(conflicting)
-
-
-async def create_appointment(
-    conn: AppointmentConnection, title: str, start_time: datetime, end_time: datetime
+async def write_document(
+    conn: DocumentConnection, document_id: str, title: str, content: str
 ) -> dict:
-    """Create and return a new appointment."""
+    """Create or update and return a document."""
     row = await conn.fetchrow(
         """
-        INSERT INTO appointments (title, start_time, end_time)
+        INSERT INTO documents (id, title, content)
         VALUES ($1, $2, $3)
-        RETURNING id, title, start_time, end_time
+        ON CONFLICT (id)
+        DO UPDATE SET title = EXCLUDED.title, content = EXCLUDED.content
+        RETURNING id, title, content
         """,
+        document_id,
         title,
-        start_time,
-        end_time,
+        content,
     )
-    appointment = _row_to_appointment(row)
-    if appointment is None:
-        return {"title": title, "start_time": start_time, "end_time": end_time}
-    return appointment
+    document = _row_to_document(row)
+    if document is None:
+        return {"id": document_id, "title": title, "content": content}
+    return document
 
 
-async def get_appointment(
-    conn: AppointmentConnection, appointment_id: int
-) -> dict | None:
-    """Fetch a single appointment by id."""
+async def get_document(conn: DocumentConnection, document_id: str) -> dict | None:
+    """Fetch a single document by id."""
     row = await conn.fetchrow(
         """
-        SELECT id, title, start_time, end_time
-        FROM appointments
+        SELECT id, title, content
+        FROM documents
         WHERE id = $1
         """,
-        appointment_id,
+        document_id,
     )
-    return _row_to_appointment(row)
+    return _row_to_document(row)
 
 
-async def get_appointments(conn: AppointmentConnection) -> list[dict]:
-    """List appointments ordered by start time."""
-    rows = await conn.fetch(
-        """
-        SELECT id, title, start_time, end_time
-        FROM appointments
-        ORDER BY start_time
-        """
-    )
-    return [appointment for row in rows if (appointment := _row_to_appointment(row))]
-
-
-async def update_appointment(
-    conn: AppointmentConnection,
-    appointment_id: int,
-    title: str,
-    start_time: datetime,
-    end_time: datetime,
-) -> dict | None:
-    """Update an appointment and return the updated row when found."""
-    row = await conn.fetchrow(
-        """
-        UPDATE appointments
-        SET title = $1, start_time = $2, end_time = $3
-        WHERE id = $4
-        RETURNING id, title, start_time, end_time
-        """,
-        title,
-        start_time,
-        end_time,
-        appointment_id,
-    )
-    return _row_to_appointment(row)
-
-
-async def delete_appointment(conn: AppointmentConnection, appointment_id: int) -> None:
-    """Delete an appointment by id."""
-    await conn.execute("DELETE FROM appointments WHERE id = $1", appointment_id)
+async def delete_document(conn: DocumentConnection, document_id: str) -> None:
+    """Delete a document by id."""
+    await conn.execute("DELETE FROM documents WHERE id = $1", document_id)
 
 
 __all__ = [
-    "AppointmentConnection",
-    "create_appointment",
-    "delete_appointment",
-    "get_appointment",
-    "get_appointments",
-    "has_conflict",
-    "update_appointment",
+    "DocumentConnection",
+    "delete_document",
+    "get_document",
+    "write_document",
 ]

--- a/src/backend/web/rest/main.py
+++ b/src/backend/web/rest/main.py
@@ -5,4 +5,4 @@ app = FastAPI()
 
 @app.get("/")
 def read_root():
-    return {"message": "Welcome to the FastAPI AI API integration"}
+    return {"message": "Welcome to the FastAPI template"}

--- a/tests/test_backend_document_workflow.py
+++ b/tests/test_backend_document_workflow.py
@@ -1,0 +1,216 @@
+import asyncio
+
+import pytest
+
+from src.backend import handlers as document_handlers
+from src.backend.controller import DocumentController
+from src.backend.gateway import DocumentGateway
+from src.backend.handlers import (
+    handle_delete_document,
+    handle_get_document,
+    handle_write_document,
+)
+from src.backend.repository import delete_document, get_document, write_document
+
+
+class FakeConn:
+    def __init__(self):
+        self.calls = []
+        self.documents = {}
+
+    async def execute(self, query, *args):
+        self.calls.append((query, args))
+        if "DELETE FROM documents" in query:
+            self.documents.pop(args[0], None)
+
+    async def fetchrow(self, query, *args):
+        self.calls.append((query, args))
+
+        if "INSERT INTO documents" in query and "RETURNING" in query:
+            document = {"id": args[0], "title": args[1], "content": args[2]}
+            self.documents[document["id"]] = document
+            return document
+
+        if "SELECT id, title, content" in query:
+            return self.documents.get(args[0])
+
+        return None
+
+
+class FakeConnNoReturn(FakeConn):
+    async def fetchrow(self, query, *args):
+        self.calls.append((query, args))
+        if "INSERT INTO documents" in query and "RETURNING" in query:
+            return None
+        return await super().fetchrow(query, *args)
+
+
+class FakeRepository:
+    def __init__(self):
+        self.calls = []
+
+    async def get_document(self, conn, document_id):
+        self.calls.append(("get_document", conn, document_id))
+        return {"id": document_id, "title": "Title", "content": "Body"}
+
+    async def write_document(self, conn, document_id, title, content):
+        self.calls.append(("write_document", conn, document_id, title, content))
+        return {"id": document_id, "title": title, "content": content}
+
+    async def delete_document(self, conn, document_id):
+        self.calls.append(("delete_document", conn, document_id))
+
+
+class FakeGateway:
+    def __init__(self):
+        self.calls = []
+        self.documents = {"doc-1": {"id": "doc-1", "title": "Initial", "content": "Body"}}
+
+    async def get_document(self, document_id):
+        self.calls.append(("get_document", document_id))
+        return self.documents.get(document_id)
+
+    async def write_document(self, document_id, title, content):
+        self.calls.append(("write_document", document_id, title, content))
+        document = {"id": document_id, "title": title, "content": content}
+        self.documents[document_id] = document
+        return document
+
+    async def delete_document(self, document_id):
+        self.calls.append(("delete_document", document_id))
+        self.documents.pop(document_id, None)
+
+
+def test_repository_document_roundtrip():
+    conn = FakeConn()
+
+    created = asyncio.run(write_document(conn, "doc-1", "Title", "Body"))
+    fetched = asyncio.run(get_document(conn, "doc-1"))
+
+    assert created == {"id": "doc-1", "title": "Title", "content": "Body"}
+    assert fetched == created
+
+    asyncio.run(delete_document(conn, "doc-1"))
+    assert asyncio.run(get_document(conn, "doc-1")) is None
+
+
+def test_repository_write_returns_fallback_payload_when_row_missing():
+    conn = FakeConnNoReturn()
+
+    created = asyncio.run(write_document(conn, "doc-1", "Title", "Body"))
+
+    assert created == {"id": "doc-1", "title": "Title", "content": "Body"}
+
+
+def test_gateway_delegates_to_repository_with_connection_context():
+    conn = object()
+    repository = FakeRepository()
+    gateway = DocumentGateway(conn, repository=repository)
+
+    fetched = asyncio.run(gateway.get_document("doc-1"))
+    written = asyncio.run(gateway.write_document("doc-1", "Title", "Body"))
+    asyncio.run(gateway.delete_document("doc-1"))
+
+    assert fetched == {"id": "doc-1", "title": "Title", "content": "Body"}
+    assert written == {"id": "doc-1", "title": "Title", "content": "Body"}
+    assert repository.calls == [
+        ("get_document", conn, "doc-1"),
+        ("write_document", conn, "doc-1", "Title", "Body"),
+        ("delete_document", conn, "doc-1"),
+    ]
+
+
+def test_controller_normalizes_before_write():
+    gateway = FakeGateway()
+    controller = DocumentController(gateway)
+
+    result = asyncio.run(
+        controller.write_document("  doc-1  ", "  Example   Title  ", " body ")
+    )
+
+    assert result == {"id": "doc-1", "title": "Example Title", "content": "body"}
+    assert gateway.calls == [("write_document", "doc-1", "Example Title", "body")]
+
+
+def test_controller_delete_rejects_missing_document():
+    gateway = FakeGateway()
+    gateway.documents = {}
+    controller = DocumentController(gateway)
+
+    with pytest.raises(ValueError, match="document not found"):
+        asyncio.run(controller.delete_document("doc-1"))
+
+    assert gateway.calls == [("get_document", "doc-1")]
+
+
+def test_handler_returns_error_for_missing_write_field():
+    controller = DocumentController(FakeGateway())
+
+    result = asyncio.run(
+        handle_write_document(
+            controller,
+            {"id": "doc-1", "title": "Title"},
+        )
+    )
+
+    assert result == {"status": "error", "error": "'content'"}
+
+
+def test_handler_controller_gateway_repository_integration():
+    conn = FakeConn()
+    gateway = DocumentGateway(conn)
+    controller = DocumentController(gateway)
+
+    created = asyncio.run(
+        handle_write_document(
+            controller,
+            {"id": " doc-1 ", "title": "  Example   Title  ", "content": " body "},
+        )
+    )
+    assert created == {
+        "status": "ok",
+        "document": {"id": "doc-1", "title": "Example Title", "content": "body"},
+    }
+
+    fetched = asyncio.run(handle_get_document(controller, "doc-1"))
+    assert fetched == {
+        "status": "ok",
+        "document": {"id": "doc-1", "title": "Example Title", "content": "body"},
+    }
+
+    deleted = asyncio.run(handle_delete_document(controller, "doc-1"))
+    assert deleted == {"status": "ok", "deleted_id": "doc-1"}
+
+    missing = asyncio.run(handle_get_document(controller, "doc-1"))
+    assert missing == {"status": "error", "error": "document not found"}
+
+
+def test_handler_writes_document_sample_artifact(tmp_path, monkeypatch):
+    artifact_path = tmp_path / "document-crud-template.md"
+    monkeypatch.setattr(document_handlers, "DOCUMENT_SAMPLE_ARTIFACT_PATH", artifact_path)
+
+    controller = DocumentController(FakeGateway())
+    created = asyncio.run(
+        handle_write_document(
+            controller,
+            {"id": "doc-1", "title": "Title", "content": "Body"},
+        )
+    )
+
+    assert created["status"] == "ok"
+    assert artifact_path.exists()
+    artifact_content = artifact_path.read_text(encoding="utf-8")
+    assert "tag: document-crud-template" in artifact_content
+    assert "scenario: write-document" in artifact_content
+
+
+def test_document_sample_artifact_exists_with_expected_tag_and_scenario():
+    artifact_path = document_handlers.DOCUMENT_SAMPLE_ARTIFACT_PATH
+
+    assert artifact_path.exists()
+    artifact_content = artifact_path.read_text(encoding="utf-8")
+    assert f"tag: {document_handlers.DOCUMENT_SAMPLE_ARTIFACT_TAG}" in artifact_content
+    assert (
+        f"scenario: {document_handlers.DOCUMENT_SAMPLE_ARTIFACT_SCENARIO}"
+        in artifact_content
+    )

--- a/tests/test_core_document_workflow.py
+++ b/tests/test_core_document_workflow.py
@@ -1,0 +1,80 @@
+import asyncio
+
+import pytest
+
+from src.backend.core import prepare_document_record, write_document_sample
+from src.backend.db.postgres import write_document
+
+
+class FakeConn:
+    def __init__(self):
+        self.calls = []
+        self.documents = {}
+
+    async def fetchrow(self, query, *args):
+        self.calls.append((query, args))
+        if "INSERT INTO documents" in query and "RETURNING" in query:
+            document = {"id": args[0], "title": args[1], "content": args[2]}
+            self.documents[document["id"]] = document
+            return document
+        return None
+
+
+class FakeConnNoReturn(FakeConn):
+    async def fetchrow(self, query, *args):
+        self.calls.append((query, args))
+        if "INSERT INTO documents" in query and "RETURNING" in query:
+            return None
+        return await super().fetchrow(query, *args)
+
+
+def test_prepare_document_record_normalizes_fields():
+    record = prepare_document_record("  doc-1  ", "  Sample   Document  ", " body ")
+
+    assert record.id == "doc-1"
+    assert record.title == "Sample Document"
+    assert record.content == "body"
+
+
+def test_prepare_document_record_rejects_missing_identifier():
+    with pytest.raises(ValueError, match="document_id must not be empty"):
+        prepare_document_record("   ", "Title", "body")
+
+
+def test_prepare_document_record_rejects_non_string_title():
+    with pytest.raises(ValueError, match="title must be a string"):
+        prepare_document_record("doc-1", 123, "body")
+
+
+def test_write_document_sample_persists_normalized_record():
+    conn = FakeConn()
+
+    result = asyncio.run(
+        write_document_sample(conn, "  doc-1  ", "  Sample   Document  ", " body ")
+    )
+
+    assert result.id == "doc-1"
+    assert result.title == "Sample Document"
+    assert result.content == "body"
+    assert len(conn.calls) == 1
+    assert "INSERT INTO documents" in conn.calls[0][0]
+    assert conn.calls[0][1] == ("doc-1", "Sample Document", "body")
+
+
+def test_write_document_sample_returns_fallback_payload_when_row_missing():
+    conn = FakeConnNoReturn()
+
+    result = asyncio.run(write_document_sample(conn, "doc-1", "Title", "Body"))
+
+    assert result == {"id": "doc-1", "title": "Title", "content": "Body"}
+
+
+def test_db_write_document_uses_core_normalization():
+    conn = FakeConn()
+
+    result = asyncio.run(write_document(conn, " doc-1 ", " Example   Title ", " text "))
+
+    assert result.id == "doc-1"
+    assert result.title == "Example Title"
+    assert result.content == "text"
+    assert conn.calls[0][1] == ("doc-1", "Example Title", "text")

--- a/tests/test_sandbox_document_workflow.py
+++ b/tests/test_sandbox_document_workflow.py
@@ -1,0 +1,96 @@
+import asyncio
+from pathlib import Path
+
+from sandbox.document import handlers as document_handlers
+from sandbox.document.controller import DocumentController
+from sandbox.document.gateway import DocumentGateway
+from sandbox.document.handlers import (
+    handle_delete_document,
+    handle_get_document,
+    handle_write_document,
+)
+from sandbox.document.repository import delete_document, get_document, write_document
+
+
+class FakeConn:
+    def __init__(self):
+        self.calls = []
+        self.documents = {}
+
+    async def execute(self, query, *args):
+        self.calls.append((query, args))
+        if "DELETE FROM documents" in query:
+            self.documents.pop(args[0], None)
+
+    async def fetchrow(self, query, *args):
+        self.calls.append((query, args))
+
+        if "INSERT INTO documents" in query and "RETURNING" in query:
+            document = {"id": args[0], "title": args[1], "content": args[2]}
+            self.documents[document["id"]] = document
+            return document
+
+        if "SELECT id, title, content" in query:
+            return self.documents.get(args[0])
+
+        return None
+
+
+def test_sandbox_repository_roundtrip():
+    conn = FakeConn()
+
+    created = asyncio.run(write_document(conn, "doc-1", "Title", "Body"))
+    fetched = asyncio.run(get_document(conn, "doc-1"))
+
+    assert created == {"id": "doc-1", "title": "Title", "content": "Body"}
+    assert fetched == created
+
+    asyncio.run(delete_document(conn, "doc-1"))
+    assert asyncio.run(get_document(conn, "doc-1")) is None
+
+
+def test_sandbox_handlers_integration_and_artifact(tmp_path, monkeypatch):
+    artifact_path = tmp_path / "sandbox-document-crud-template.md"
+    monkeypatch.setattr(document_handlers, "DOCUMENT_SAMPLE_ARTIFACT_PATH", artifact_path)
+
+    conn = FakeConn()
+    gateway = DocumentGateway(conn)
+    controller = DocumentController(gateway)
+
+    created = asyncio.run(
+        handle_write_document(
+            controller,
+            {"id": "doc-1", "title": "  Sandbox   Title ", "content": " body "},
+        )
+    )
+    assert created == {
+        "status": "ok",
+        "document": {"id": "doc-1", "title": "Sandbox Title", "content": "body"},
+    }
+
+    fetched = asyncio.run(handle_get_document(controller, "doc-1"))
+    assert fetched["status"] == "ok"
+    assert fetched["document"]["id"] == "doc-1"
+
+    deleted = asyncio.run(handle_delete_document(controller, "doc-1"))
+    assert deleted == {"status": "ok", "deleted_id": "doc-1"}
+
+    assert artifact_path.exists()
+    artifact_content = artifact_path.read_text(encoding="utf-8")
+    assert "tag: sandbox-document-crud-template" in artifact_content
+    assert "scenario: write-document" in artifact_content
+
+
+def test_sandbox_document_sample_artifact_exists():
+    artifact_path = (
+        Path(__file__).resolve().parents[1]
+        / "sandbox"
+        / "document"
+        / "e2e"
+        / "sandbox-document-crud-template.md"
+    )
+
+    assert artifact_path.exists()
+    artifact_content = artifact_path.read_text(encoding="utf-8")
+    assert "tag: sandbox-document-crud-template" in artifact_content
+    assert "scenario: write-document" in artifact_content


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Linked Linear Ticket
Fixes BER-101
https://linear.app/baek/issue/BER-101/replace-appointment-specific-sample-workflow-with-generic-document

## Instruction
Implement the approved Berry ticket: Replace appointment-specific sample workflow with generic document CRUD template and README updates.
Repository: https://github.com/bryanbaek/pypy
Base branch: main

Approved ticket description:
## Summary
Convert the repository from an appointment/business-booking example into a domain-neutral FastAPI template by removing appointment-specific workflow logic and replacing it with a minimal document CRUD sample. The new sample should demonstrate how the framework is organized across controller/core/repository-style layers without encoding business-domain rules like scheduling validation or overlap detection.

## Scope
- Remove or replace appointment-specific example code under `src/backend` and `sandbox/appointment` with a generic `document` sample flow.
- Introduce a minimal CRUD example for documents that covers at least read, write/create-or-update, and delete behaviors.
- Keep the implementation intentionally simple and template-oriented so future users can copy the structure rather than inherit domain logic.
- Update tests under `tests/` so the default repository test suite validates the generic CRUD sample instead of appointment workflows.
- Update `README.md` to describe the repo as a FastAPI template, explain the generic sample module layout, and document how to run and verify the sample.
- Ensure existing CI surfaces in `.github/workflows/*.yml` continue to pass without requiring appointment-specific fixtures or terminology.

## Acceptance Criteria
- No default example code, test names, or README sections present the repository as an appointment booking or ecommerce application.
- `src/backend` exposes a generic document-oriented sample workflow that demonstrates the intended layering for a FastAPI template.
- The sample supports these basic operations with passing automated tests: get document, write/create document, delete document.
- Any domain-specific validation concepts tied to appointments (such as business hours, same-day enforcement, title normalization for bookings, or overlap conflict logic) are removed from the default sample path.
- Sandbox/example code is renamed or rewritten so users see a generic template example rather than `sandbox/appointment` behavior.
- `README.md` explains the project as a reusable Python/FastAPI template, documents the sample CRUD flow, and points contributors to the main implementation and test files.
- Repository test and lint workflows remain green using the updated generic sample.

## Helpful Files
- `README.md`
- `src/backend/controller/__init__.py`
- `src/backend/core/__init__.py`
- `src/backend/db`
- `sandbox/appointment/controller.py`
- `tests/test_backend_appointment_workflow.py`
- `tests/test_core_workflow.py`
- `tests/test_sandbox_appointment_workflow.py`
- `.github/workflows/python-app.yml`
- `.github/workflows/pylint.yml`

## Out of Scope
- Adding a production-ready authentication, authorization, or multi-tenant data model.
- Building a full generic resource framework for arbitrary entities beyond the single illustrative document sample.
- Reworking CI workflow definitions unless changes are required to keep existing checks passing after the sample rename.
- Expanding the template into a full plugin system or scaffolding CLI.

## Codex Output
### Initial Draft
> Replaced the default sample with a generic document CRUD template and removed the appointment-specific flow. The backend layer now exposes `get`, `write` (create-or-update), and `delete` document operations in [src/backend/core/__init__.py](/job/repo/src/backend/core/__init__.py), [src/backend/controller/__init__.py](/job/repo/src/backend/controller/__init__.py), [src/backend/repository/__init_...

## Validation
- `just lint`: passed
- `just test`: passed

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.venv`