### PR TITLE
Implement a small safe change and add tests

### DIFF
--- a/sandbox/document/handlers.py
+++ b/sandbox/document/handlers.py
@@ -51,7 +51,10 @@ async def handle_write_document(
 async def handle_get_document(
     controller: DocumentControllerContract, document_id: str
 ) -> dict:
-    document = await controller.get_document(document_id)
+    try:
+        document = await controller.get_document(document_id)
+    except ValueError as exc:
+        return {"status": "error", "error": str(exc)}
     if document is None:
         return {"status": "error", "error": "document not found"}
     return {"status": "ok", "document": document}

--- a/src/backend/controller/__init__.py
+++ b/src/backend/controller/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import Protocol
 
-from src.backend.core import prepare_document_record
+from src.backend.core import normalize_document_id, prepare_document_record
 
 
 class DocumentGatewayContract(Protocol):
@@ -32,16 +32,17 @@ class DocumentController:
 
     async def get_document(self, document_id: str) -> dict | None:
         """Fetch a single document by id."""
-        return await self._gateway.get_document(document_id)
+        return await self._gateway.get_document(normalize_document_id(document_id))
 
     async def delete_document(self, document_id: str) -> dict:
         """Delete a document and return a normalized response payload."""
-        existing = await self._gateway.get_document(document_id)
+        normalized_document_id = normalize_document_id(document_id)
+        existing = await self._gateway.get_document(normalized_document_id)
         if existing is None:
             raise ValueError("document not found")
 
-        await self._gateway.delete_document(document_id)
-        return {"deleted_id": document_id}
+        await self._gateway.delete_document(normalized_document_id)
+        return {"deleted_id": normalized_document_id}
 
 
 __all__ = ["DocumentController", "DocumentGatewayContract"]

--- a/src/backend/core/__init__.py
+++ b/src/backend/core/__init__.py
@@ -38,6 +38,11 @@ def prepare_document_record(document_id: str, title: str, content: str) -> Docum
     )
 
 
+def normalize_document_id(document_id: str) -> str:
+    """Normalize a document identifier for non-write document operations."""
+    return _normalize_required_text("document_id", document_id)
+
+
 def _record_to_dict(record: DocumentRecord) -> dict:
     return {"id": record.id, "title": record.title, "content": record.content}
 
@@ -64,4 +69,10 @@ async def write_document_sample(
     return DocumentRecord(id=row["id"], title=row["title"], content=row["content"])
 
 
-__all__ = ["DocumentRecord", "DocumentWriteConnection", "prepare_document_record", "write_document_sample"]
+__all__ = [
+    "DocumentRecord",
+    "DocumentWriteConnection",
+    "normalize_document_id",
+    "prepare_document_record",
+    "write_document_sample",
+]

--- a/src/backend/handlers/__init__.py
+++ b/src/backend/handlers/__init__.py
@@ -54,7 +54,10 @@ async def handle_get_document(
     controller: DocumentControllerContract, document_id: str
 ) -> dict:
     """Handle get-document requests."""
-    document = await controller.get_document(document_id)
+    try:
+        document = await controller.get_document(document_id)
+    except ValueError as exc:
+        return {"status": "error", "error": str(exc)}
     if document is None:
         return {"status": "error", "error": "document not found"}
     return {"status": "ok", "document": document}

--- a/tests/test_backend_document_workflow.py
+++ b/tests/test_backend_document_workflow.py
@@ -132,6 +132,16 @@ def test_controller_normalizes_before_write():
     assert gateway.calls == [("write_document", "doc-1", "Example Title", "body")]
 
 
+def test_controller_normalizes_identifier_before_get():
+    gateway = FakeGateway()
+    controller = DocumentController(gateway)
+
+    result = asyncio.run(controller.get_document("  doc-1  "))
+
+    assert result == {"id": "doc-1", "title": "Initial", "content": "Body"}
+    assert gateway.calls == [("get_document", "doc-1")]
+
+
 def test_controller_delete_rejects_missing_document():
     gateway = FakeGateway()
     gateway.documents = {}
@@ -141,6 +151,16 @@ def test_controller_delete_rejects_missing_document():
         asyncio.run(controller.delete_document("doc-1"))
 
     assert gateway.calls == [("get_document", "doc-1")]
+
+
+def test_controller_normalizes_identifier_before_delete():
+    gateway = FakeGateway()
+    controller = DocumentController(gateway)
+
+    result = asyncio.run(controller.delete_document("  doc-1  "))
+
+    assert result == {"deleted_id": "doc-1"}
+    assert gateway.calls == [("get_document", "doc-1"), ("delete_document", "doc-1")]
 
 
 def test_handler_returns_error_for_missing_write_field():
@@ -154,6 +174,14 @@ def test_handler_returns_error_for_missing_write_field():
     )
 
     assert result == {"status": "error", "error": "'content'"}
+
+
+def test_handler_returns_error_for_invalid_get_identifier():
+    controller = DocumentController(FakeGateway())
+
+    result = asyncio.run(handle_get_document(controller, "   "))
+
+    assert result == {"status": "error", "error": "document_id must not be empty"}
 
 
 def test_handler_controller_gateway_repository_integration():

--- a/tests/test_core_document_workflow.py
+++ b/tests/test_core_document_workflow.py
@@ -2,7 +2,11 @@ import asyncio
 
 import pytest
 
-from src.backend.core import prepare_document_record, write_document_sample
+from src.backend.core import (
+    normalize_document_id,
+    prepare_document_record,
+    write_document_sample,
+)
 from src.backend.db.postgres import write_document
 
 
@@ -44,6 +48,10 @@ def test_prepare_document_record_rejects_missing_identifier():
 def test_prepare_document_record_rejects_non_string_title():
     with pytest.raises(ValueError, match="title must be a string"):
         prepare_document_record("doc-1", 123, "body")
+
+
+def test_normalize_document_id_trims_surrounding_whitespace():
+    assert normalize_document_id("  doc-1  ") == "doc-1"
 
 
 def test_write_document_sample_persists_normalized_record():

--- a/tests/test_sandbox_document_workflow.py
+++ b/tests/test_sandbox_document_workflow.py
@@ -81,6 +81,14 @@ def test_sandbox_handlers_integration_and_artifact(tmp_path, monkeypatch):
     assert "scenario: write-document" in artifact_content
 
 
+def test_sandbox_handler_returns_error_for_invalid_get_identifier():
+    controller = DocumentController(DocumentGateway(FakeConn()))
+
+    result = asyncio.run(handle_get_document(controller, "   "))
+
+    assert result == {"status": "error", "error": "document_id must not be empty"}
+
+
 def test_sandbox_document_sample_artifact_exists():
     artifact_path = (
         Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Instruction
Implement a small safe change and add tests.

## Codex Output
### Initial Draft
> Implemented a small safe document-workflow change: document `get` and `delete` now normalize and validate `document_id` the same way `write` already did, and invalid `get` requests now return structured handler errors instead of bubbling `ValueError`. The core/helper and controller changes are in [src/backend/core/__init__.py](/job/repo/src/backend/core/__init__.py#L41), [src/backend/controller...

## Validation
- `just lint`: passed
- `just test`: passed

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.venv`