### PR TITLE
BER-104: Add tagged sandbox appointment e2e artifact for e2e-20260320T051727Z happy-path verification

### DIFF
--- a/sandbox/appointment/e2e/e2e-20260320T051727Z.md
+++ b/sandbox/appointment/e2e/e2e-20260320T051727Z.md
@@ -1,0 +1,4 @@
+# Sandbox Appointment Happy-Path Verification Artifact
+
+tag: e2e-20260320T051727Z
+scenario: happy

--- a/tests/test_sandbox_appointment_workflow.py
+++ b/tests/test_sandbox_appointment_workflow.py
@@ -704,3 +704,18 @@ def test_tagged_happy_path_marker_artifact_exists_with_expected_tag_and_scenario
     artifact_content = artifact_path.read_text(encoding="utf-8")
     assert "tag: core-mvp-20260319T233431Z-happy" in artifact_content
     assert "scenario: happy" in artifact_content
+
+
+def test_tagged_e2e_happy_path_artifact_exists_with_expected_tag_and_scenario():
+    artifact_path = (
+        Path(__file__).resolve().parents[1]
+        / "sandbox"
+        / "appointment"
+        / "e2e"
+        / "e2e-20260320T051727Z.md"
+    )
+
+    assert artifact_path.exists()
+    artifact_content = artifact_path.read_text(encoding="utf-8")
+    assert "tag: e2e-20260320T051727Z" in artifact_content
+    assert "scenario: happy" in artifact_content


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Linked Linear Ticket
Fixes BER-104
https://linear.app/baek/issue/BER-104/add-tagged-sandbox-appointment-e2e-artifact-for-e2e-20260320t051727z

## Instruction
Implement the approved Berry ticket: Add tagged sandbox appointment e2e artifact for e2e-20260320T051727Z happy-path verification.
Repository: https://github.com/bryanbaek/pypy
Base branch: main

Approved ticket description:
## Summary
Add a run-specific sandbox appointment e2e artifact for the tagged verification run `e2e-20260320T051727Z` and cover it with a focused happy-path test. This should be a minimal follow-up change that preserves the existing appointment workflow shape and does not alter the repository/gateway/controller/handler behavior beyond what is required to surface the new tagged artifact.

## Scope
- Add a new marker artifact at `sandbox/appointment/e2e/e2e-20260320T051727Z.md`.
- Ensure the file contents include the exact tag `e2e-20260320T051727Z` and scenario `happy`.
- Update `tests/test_sandbox_appointment_workflow.py` or add a narrowly scoped new test file to assert the happy-path sandbox appointment flow includes or references the tagged artifact.
- Keep changes localized to the sandbox appointment e2e surface and its test coverage.
- Preserve the current backend layering expectations described in `README.md` and avoid unnecessary workflow refactors.

## Acceptance Criteria
- `sandbox/appointment/e2e/e2e-20260320T051727Z.md` exists in the repository.
- The artifact file contains the literal string `e2e-20260320T051727Z`.
- The artifact file contains the literal string `happy`.
- A sandbox appointment workflow test in `tests/test_sandbox_appointment_workflow.py` or a new targeted test file asserts the presence of the tagged artifact as part of happy-path coverage.
- Existing appointment workflow behavior remains intact; no broad changes are made to repository/gateway/controller/handler flow outside the minimum required for this verification.
- The test suite relevant to the sandbox appointment workflow passes locally and in existing Python CI.

## Helpful Files
- `sandbox/appointment/controller.py`
- `sandbox/appointment/e2e/core-mvp-20260319T170333Z-happy.md`
- `tests/test_sandbox_appointment_workflow.py`
- `tests/test_backend_appointment_workflow.py`
- `README.md`

## Out of Scope
- Refactoring the appointment workflow architecture.
- Changing generic document sample behavior in `src/backend/*`.
- Introducing new CI workflows or modifying `.github/workflows/*` unless required by an existing failing test path.
- Adding additional scenarios beyond this single tagged `happy` verification run.
- Expanding this work into PR creation or Linear automation beyond drafting the implementation ticket requirements.

## Codex Output
### Initial Draft
> Implemented the requested sandbox-only follow-up change.
>
> Changed [sandbox/appointment/e2e/e2e-20260320T051727Z.md](/job/repo/sandbox/appointment/e2e/e2e-20260320T051727Z.md) to add the new tagged happy-path artifact with the literal tag `e2e-20260320T051727Z` and scenario `happy`. Updated [tests/test_sandbox_appointment_workflow.py](/job/repo/tests/test_sandbox_appointment_workflow.py) with on...

## Validation
- `just lint`: passed
- `just test`: passed

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.venv`