### PR TITLE
BER-118: Align Justfile test/lint commands with repo verification workflow

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,6 @@
 lint:
-  test -f README.md
+  uv run ruff check .
+  uv run ty check
 
 test:
-  test -f tests/test_backend_document_workflow.py
+  uv run pytest tests

--- a/README.md
+++ b/README.md
@@ -37,15 +37,19 @@ The included FastAPI app starts from `src/backend/web/rest/main.py`.
 
 ## Verify
 
-The default sample is exercised by the repository test suite:
+After syncing dependencies, run the repository verification commands from the repo root:
 
 ```bash
-uv run pytest
+just lint
+just test
 ```
+
+`just lint` runs `uv run ruff check .` followed by `uv run ty check`.
+`just test` runs `uv run pytest tests`.
 
 ## Development
 
-For repo checks during development, `just lint` runs the repo lint checks and `just test` runs the repo test suite.
+For repo checks during development, use `just lint` and `just test` after `uv sync`.
 
 The main files to inspect while adapting the template are:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "mypy>=1.11.2",
     "ruff>=0.6.9",
+    "ty>=0.0.24",
     "pre-commit>=4.0.1",
     "pylint>=3.3.1",
     "typing-extensions>=4.12.2",


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Linked Linear Ticket
Fixes BER-118
https://linear.app/baek/issue/BER-118/align-justfile-testlint-commands-with-repo-verification-workflow

## Instruction
Implement the approved Berry ticket: Align Justfile test/lint commands with repo verification workflow.
Repository: https://github.com/bryanbaek/pypy
Base branch: main

Approved ticket description:
## Summary
Update the repository automation entrypoints so local developer commands and CI use the same verification flow. `Justfile` should define `just test` to run the full repo test suite and `just lint` to run `ruff check .` and `ty check`. Update `README.md` and the existing GitHub workflow files only where needed so documented and automated verification paths match these commands.

## Scope
- Update `Justfile` targets for test and lint execution.
- Ensure `just test` executes the full repository test suite under `tests/`.
- Ensure `just lint` runs `ruff check .` and `ty check` in that order unless the existing repo conventions require otherwise.
- Review `.github/workflows/makefile.yml`, `.github/workflows/pylint.yml`, and `.github/workflows/python-app.yml` and adjust existing jobs only as needed so CI aligns with the `Justfile` commands.
- Update `README.md` verification/setup guidance so the documented commands match the final `Justfile` and workflow behavior.

## Acceptance Criteria
- Running `just test` from the repo root executes the repository's full automated test suite.
- Running `just lint` from the repo root executes `ruff check .` and `ty check`.
- Existing GitHub Actions workflows that cover linting and tests reference the same verification commands or remain clearly consistent with them without introducing duplicate conflicting command definitions.
- `README.md` documents the correct local verification commands for tests and linting.
- Changes are limited to `Justfile`, `README.md`, and existing workflow files unless a minimal supporting edit is required to make those commands functional.

## Helpful Files
- `Justfile`
- `README.md`
- `.github/workflows/makefile.yml`
- `.github/workflows/pylint.yml`
- `.github/workflows/python-app.yml`
- `pyproject.toml`
- `tests/test_backend_appointment_workflow.py`
- `tests/test_backend_document_workflow.py`
- `tests/test_backend_web_rest_main.py`
- `tests/test_core_document_workflow.py`
- `tests/test_core_workflow.py`

## Out of Scope
- Refactoring backend application code in `src/backend`.
- Adding new CI pipelines or replacing the current workflow structure.
- Broad documentation cleanup beyond verification command updates.
- Expanding lint/type/test tooling beyond `ruff check .`, `ty check`, and the existing test suite.

## Codex Output
### Initial Draft
> Implemented the verification alignment in [Justfile](/job/repo/Justfile#L1), [README.md](/job/repo/README.md#L38), [pyproject.toml](/job/repo/pyproject.toml#L10), [makefile.yml](/job/repo/.github/workflows/makefile.yml#L1), [pylint.yml](/job/repo/.github/workflows/pylint.yml#L1), and [python-app.yml](/job/repo/.github/workflows/python-app.yml#L1).
>
> `just lint` now runs `uv run ruff check .` fol...

## Validation
- `just lint`: warning
- `just test`: warning

## Validation Warnings
- Berry opened this PR with `PR_DRAFT_VALIDATION_MODE=warn_only`.
- local validation warnings did not block PR opening.
- `just lint` new local validation failures: Default value of type `<module 'src.backend.repository'>` is not assignable to annotated parameter type `DocumentRepository` (src/backend/gateway/__init__.py:29:9), Module `src.backend.controller` has no member `AppointmentController` (tests/test_backend_appointment_workflow.py:7:36), Module `src.backend.gateway` has no member `AppointmentGateway` (tests/test_backend_appointment_workflow.py:8:33)
- `just test` new local validation failures: Recipe `test` failed on line 6 with exit code 2

## Push Warnings
- Berry opened this PR after a partial push fallback: GitHub rejected workflow file changes during push, so Berry retried without `.github/workflows/*` edits..
- Omitted workflow paths from the pushed branch: `.github/workflows/makefile.yml`, `.github/workflows/pylint.yml`, `.github/workflows/python-app.yml`
- Original branch `berry/codex-pr/BER-118-align-justfile-test-lint-7b7a096d` was retried as `berry/codex-pr/BER-118-align-justfile-test-lint-7b7a096d-partial`.

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.pytest_cache`, `.ruff_cache`, `.venv`
- Reverted unexpected files before commit: `uv.lock`