### PR TITLE
BER-123: Add a Bun + Vite + TypeScript frontend demo page wired into the FastAPI template

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -75,6 +75,7 @@ chromadb_data/
 dist/
 build/
 *.egg-info/
+node_modules/
 
 # Dependencies (will be installed in container)
 Pipfile

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # FastAPI Template
 
-This repository is a reusable Python/FastAPI template with a small document CRUD sample. The default example is intentionally domain-neutral so you can copy the layer boundaries without inheriting business-specific rules.
+This repository is a reusable Python/FastAPI template with a small document CRUD sample. The default example is intentionally domain-neutral so you can copy the layer boundaries without inheriting business-specific rules. A minimal Bun + Vite + TypeScript frontend starter also lives alongside the backend so the template includes a simple browser-facing demo surface.
 
 ## Sample Layout
 
-The template demonstrates a single document flow across the backend layers in `src/backend`:
+The template includes a lightweight frontend starter in `src/frontend` plus the existing document flow in `src/backend`:
 
+- `src/frontend`: Bun + Vite + TypeScript demo page for browser-facing starter work.
 - `src/backend/controller`: workflow orchestration plus input normalization for the sample document payload.
 - `src/backend/repository`: persistence helpers for `get`, `write` (create-or-update), and `delete`.
 - `src/backend/gateway`: connection-aware delegation into the repository layer.
@@ -24,22 +25,57 @@ The default sample supports three basic operations:
 `write_document` uses create-or-update semantics so the same sample covers both initial creation and later replacement.
 The controller normalizes document ids and titles before delegating to the gateway and repository layers.
 
+## Frontend Demo
+
+The frontend sample lives in `src/frontend`. It is intentionally lightweight and domain-neutral: a single Bun + Vite + TypeScript page that gives contributors a concrete place to start UI work without replacing the existing FastAPI document workflow.
+
 ## Run
 
-Install dependencies with your preferred toolchain. If you use `uv`:
+### Backend
+
+Install backend dependencies with your preferred Python toolchain. If you use `uv`:
 
 ```bash
 uv sync
 uv run uvicorn src.backend.main:app --reload
 ```
 
-To run the same application in Docker:
+The included FastAPI app starts from `src/backend/main.py`.
+
+To run the same backend application in Docker:
 
 ```bash
 docker compose up --build
 ```
 
-The included FastAPI app starts from `src/backend/main.py`.
+### Frontend
+
+The frontend starter uses Bun as its package manager/runtime. After installing Bun locally, install frontend dependencies from the repo root:
+
+```bash
+cd src/frontend
+bun install
+```
+
+Start the Vite development server:
+
+```bash
+cd src/frontend
+bun run dev
+```
+
+Then open `http://localhost:5173` in a browser. The demo page includes quick links to the FastAPI sample on `http://localhost:8000`, but the frontend starter runs as a separate dev server so it does not change the backend document example.
+
+Create a production build with:
+
+```bash
+cd src/frontend
+bun run build
+```
+
+The built assets are written to `src/frontend/dist/`.
+
+The checked-in `Dockerfile` and `docker-compose.yaml` continue to target the FastAPI app only; the frontend demo is intentionally a local Bun/Vite workflow.
 
 ## Postgres Bootstrap
 
@@ -89,6 +125,10 @@ For repo checks during development, use `just lint` and `just test` after `uv sy
 
 The main files to inspect while adapting the template are:
 
+- `src/frontend/package.json`
+- `src/frontend/index.html`
+- `src/frontend/src/main.ts`
+- `src/frontend/src/style.css`
 - `src/backend/main.py`
 - `src/backend/db/postgres.py`
 - `src/backend/db/init-db.sql`

--- a/src/frontend/.gitignore
+++ b/src/frontend/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FastAPI Template Frontend Demo</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "frontend-demo",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/src/frontend/src/main.ts
+++ b/src/frontend/src/main.ts
@@ -1,0 +1,59 @@
+import "./style.css";
+
+const app = document.querySelector<HTMLDivElement>("#app");
+
+if (!app) {
+    throw new Error("Frontend app root was not found.");
+}
+
+app.innerHTML = `
+  <main class="page-shell">
+    <section class="hero-card">
+      <p class="eyebrow">Frontend sample</p>
+      <h1>Bun + Vite + TypeScript starter</h1>
+      <p class="lede">
+        This demo page is the browser-facing companion to the FastAPI template.
+        Keep the existing document workflow in <code>src/backend</code> and use
+        <code>src/frontend</code> as a lightweight starting point for UI work.
+      </p>
+      <div class="hero-actions">
+        <a href="http://localhost:8000/" target="_blank" rel="noreferrer">
+          Open FastAPI sample
+        </a>
+        <a href="http://localhost:8000/health" target="_blank" rel="noreferrer">
+          Check backend health
+        </a>
+      </div>
+    </section>
+
+    <section class="info-grid" aria-label="Template starter details">
+      <article class="info-card">
+        <p class="card-label">Frontend code</p>
+        <h2>src/frontend</h2>
+        <p>
+          Single-page starter built with Bun, Vite, and TypeScript. The page is
+          intentionally domain-neutral so contributors can replace it with their
+          own UI without undoing template assumptions.
+        </p>
+      </article>
+
+      <article class="info-card">
+        <p class="card-label">Backend sample</p>
+        <h2>src/backend</h2>
+        <p>
+          FastAPI still owns the existing document CRUD example, health check,
+          and repository layering. Nothing in this frontend starter changes that
+          sample flow.
+        </p>
+      </article>
+
+      <article class="info-card">
+        <p class="card-label">Local commands</p>
+        <h2>Start and build</h2>
+        <p><code>bun install</code></p>
+        <p><code>bun run dev</code></p>
+        <p><code>bun run build</code></p>
+      </article>
+    </section>
+  </main>
+`;

--- a/src/frontend/src/style.css
+++ b/src/frontend/src/style.css
@@ -1,0 +1,170 @@
+:root {
+  color: #101322;
+  background:
+    radial-gradient(circle at top, rgba(255, 235, 205, 0.9), transparent 38%),
+    linear-gradient(160deg, #f8efe4 0%, #d9e6f2 52%, #f6f8fb 100%);
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+}
+
+code {
+  font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+}
+
+a {
+  color: inherit;
+}
+
+#app {
+  min-height: 100vh;
+}
+
+.page-shell {
+  width: min(1100px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 4rem 0 5rem;
+}
+
+.hero-card,
+.info-card {
+  border: 1px solid rgba(16, 19, 34, 0.08);
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 28px 80px rgba(16, 19, 34, 0.12);
+  backdrop-filter: blur(16px);
+}
+
+.hero-card {
+  padding: 3rem;
+}
+
+.eyebrow,
+.card-label {
+  margin: 0 0 0.75rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #6e6a86;
+}
+
+.hero-card h1,
+.info-card h2 {
+  margin: 0;
+  color: #171a2b;
+}
+
+.hero-card h1 {
+  max-width: 11ch;
+  font-family: "Iowan Old Style", "Palatino Linotype", serif;
+  font-size: clamp(2.9rem, 5vw, 5rem);
+  line-height: 0.95;
+}
+
+.lede {
+  max-width: 52rem;
+  margin: 1.5rem 0 0;
+  font-size: 1.1rem;
+  color: #3d465f;
+}
+
+.lede code,
+.info-card code {
+  padding: 0.16rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(16, 19, 34, 0.08);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+  margin-top: 2rem;
+}
+
+.hero-actions a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.9rem 1.2rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease,
+    background-color 160ms ease;
+}
+
+.hero-actions a:first-child {
+  background: #171a2b;
+  color: #fff9f0;
+}
+
+.hero-actions a:last-child {
+  background: rgba(255, 255, 255, 0.72);
+  color: #171a2b;
+}
+
+.hero-actions a:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px rgba(16, 19, 34, 0.16);
+}
+
+.info-grid {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.info-card {
+  padding: 1.5rem;
+}
+
+.info-card p {
+  margin: 1rem 0 0;
+  color: #44506c;
+}
+
+@media (max-width: 900px) {
+  .info-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .page-shell {
+    width: min(100% - 1.25rem, 100%);
+    padding: 2rem 0 3rem;
+  }
+
+  .hero-card,
+  .info-card {
+    border-radius: 24px;
+  }
+
+  .hero-card {
+    padding: 1.6rem;
+  }
+
+  .hero-card h1 {
+    max-width: none;
+    font-size: 2.75rem;
+  }
+}

--- a/src/frontend/src/vite-env.d.ts
+++ b/src/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/src/frontend/tsconfig.json
+++ b/src/frontend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "moduleResolution": "bundler",
+    "strict": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
+}


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Linked Linear Ticket
Fixes BER-123
https://linear.app/baek/issue/BER-123/add-a-bun-vite-typescript-frontend-demo-page-wired-into-the-fastapi

## Instruction
Implement the approved Berry ticket: Add a Bun + Vite + TypeScript frontend demo page wired into the FastAPI template.
Repository: https://github.com/bryanbaek/pypy
Base branch: main

Approved ticket description:
## Summary
Add a minimal frontend application using Bun, Vite, and TypeScript so this FastAPI template includes a simple browser-facing demo surface alongside the existing backend sample. The page should be intentionally lightweight and domain-neutral, giving contributors a concrete starting point for frontend work without changing the existing backend document workflow.

## Scope
- Create a new frontend app directory with Bun as the package manager/runtime and Vite + TypeScript as the app scaffold.
- Implement a single dummy/demo page that renders successfully and clearly indicates it is the frontend sample for this template repository.
- Ensure the frontend can be started locally alongside the existing FastAPI app using documented commands.
- Update repository documentation so a new contributor can install frontend dependencies, run the frontend dev server, and understand where the frontend code lives.
- Add any minimal ignore/configuration files needed so the frontend project fits cleanly into the current repo structure and tooling.

## Acceptance Criteria
- A new frontend workspace exists in the repository with Bun, Vite, and TypeScript configured and committed.
- Running the documented frontend start command launches a local dev server and displays the demo page in a browser.
- The demo page builds successfully with the documented production/build command.
- The frontend implementation does not break the existing Python/FastAPI project layout under `src/backend` or its current workflows.
- `README.md` documents how to install Bun dependencies, run the frontend locally, and explains the relationship between the frontend demo and the existing backend sample.
- The frontend sample is clearly scoped as a starter/demo and does not introduce business-specific behavior.

## Helpful Files
- `README.md`
- `pyproject.toml`
- `Dockerfile`
- `docker-compose.yaml`
- `src/backend/main.py`
- `src/backend/controller/document_controller.py`
- `.github/workflows/python-app.yml`
- `.github/workflows/pylint.yml`

## Out of Scope
- Building a production-ready frontend architecture beyond the initial scaffold.
- Reworking backend APIs or replacing the existing document CRUD sample.
- Adding authentication, routing complexity, or state-management libraries beyond what Vite provides by default.
- Integrating frontend build/test steps into all CI workflows unless required to keep the repo healthy.
- Containerizing the frontend unless that becomes necessary to support the documented local workflow.

## Codex Output
### Initial Draft
> Added a separate Bun/Vite/TypeScript frontend starter under [src/frontend/package.json](/job/repo/src/frontend/package.json), [src/frontend/index.html](/job/repo/src/frontend/index.html), [src/frontend/tsconfig.json](/job/repo/src/frontend/tsconfig.json), [src/frontend/src/main.ts](/job/repo/src/frontend/src/main.ts), [src/frontend/src/style.css](/job/repo/src/frontend/src/style.css), [src/fron...

## Validation
- `just lint`: warning
- `just test`: passed

## Validation Warnings
- Berry opened this PR with `PR_DRAFT_VALIDATION_MODE=warn_only`.
- local validation warnings did not block PR opening.
- `just lint` already fails on `origin/main`: Argument to bound method `__init__` is incorrect (src/backend/controller/appointment_controller_test.py:40:40), Default value of type `<module 'src.backend.repository.appointment_repository'>` is not assignable to annotated parameter type `AppointmentRepository` (src/backend/gateway/appointment_gateway.py:55:9), Default value of type `<module 'src.backend.repository.document_repository'>` is not assignable to annotated parameter type `DocumentRepository` (src/backend/gateway/document_gateway.py:31:9)

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.pytest_cache`, `.ruff_cache`, `.venv`