### PR TITLE
BER-124: Add pull request CI workflows for Python linting and automated test execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ just test
 
 `just lint` runs `uv run ruff check .` followed by `uv run ty check`.
 `just test` runs `uv run pytest`, which includes colocated `*_test.py` modules under `src/`.
+Pull requests to `main` and pushes to `main` run the same lint and test commands in GitHub Actions.
 
 ## Development
 

--- a/src/backend/controller/appointment_controller_test.py
+++ b/src/backend/controller/appointment_controller_test.py
@@ -34,6 +34,20 @@ class StubAppointmentGateway:
             "end_time": end_time,
         }
 
+    async def get_appointment(self, appointment_id: int) -> dict | None:
+        return None
+
+    async def get_appointments(self) -> list[dict]:
+        return []
+
+    async def update_appointment(
+        self, appointment_id: int, title: str, start_time: datetime, end_time: datetime
+    ) -> dict | None:
+        return None
+
+    async def delete_appointment(self, appointment_id: int) -> None:
+        return None
+
 
 def test_create_appointment_normalizes_title() -> None:
     gateway = StubAppointmentGateway()

--- a/src/backend/gateway/appointment_gateway.py
+++ b/src/backend/gateway/appointment_gateway.py
@@ -1,7 +1,7 @@
 """Gateway layer for the sample appointment workflow."""
 
 from datetime import datetime
-from typing import Protocol
+from typing import Protocol, cast
 
 import src.backend.repository.appointment_repository as default_repository
 from src.backend.repository.appointment_repository import AppointmentConnection
@@ -52,7 +52,9 @@ class AppointmentGateway:
     def __init__(
         self,
         conn: AppointmentConnection,
-        repository: AppointmentRepository = default_repository,
+        repository: AppointmentRepository = cast(
+            AppointmentRepository, default_repository
+        ),
     ) -> None:
         self._conn = conn
         self._repository = repository

--- a/src/backend/gateway/document_gateway.py
+++ b/src/backend/gateway/document_gateway.py
@@ -1,6 +1,6 @@
 """Gateway layer for the template document workflow."""
 
-from typing import Protocol
+from typing import Protocol, cast
 
 import src.backend.repository.document_repository as default_repository
 from src.backend.repository.document_repository import DocumentConnection
@@ -28,7 +28,7 @@ class DocumentGateway:
     def __init__(
         self,
         conn: DocumentConnection,
-        repository: DocumentRepository = default_repository,
+        repository: DocumentRepository = cast(DocumentRepository, default_repository),
     ) -> None:
         self._conn = conn
         self._repository = repository

--- a/src/backend/main_test.py
+++ b/src/backend/main_test.py
@@ -6,7 +6,11 @@ from src.backend.main import app, create_app
 
 
 def test_create_app_registers_expected_routes() -> None:
-    route_paths = {route.path for route in create_app().routes}
+    route_paths: set[str] = set()
+    for route in create_app().routes:
+        route_path = getattr(route, "path", None)
+        if isinstance(route_path, str):
+            route_paths.add(route_path)
 
     assert "/" in route_paths
     assert "/health" in route_paths

--- a/src/backend/repository/appointment_repository.py
+++ b/src/backend/repository/appointment_repository.py
@@ -107,7 +107,12 @@ async def get_appointments(conn: AppointmentConnection) -> list[dict]:
         ORDER BY start_time ASC
         """
     )
-    return [_row_to_appointment(row) for row in rows if row is not None]
+    appointments: list[dict] = []
+    for row in rows:
+        appointment = _row_to_appointment(row)
+        if appointment is not None:
+            appointments.append(appointment)
+    return appointments
 
 
 async def update_appointment(


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Linked Linear Ticket
Fixes BER-124
https://linear.app/baek/issue/BER-124/add-pull-request-ci-workflows-for-python-linting-and-automated-test

## Instruction
Implement the approved Berry ticket: Add pull request CI workflows for Python linting and automated test execution.
Repository: https://github.com/bryanbaek/pypy
Base branch: main

Approved ticket description:
## Summary
Add and/or standardize GitHub Actions workflows so pull requests to `main` automatically run Python linting and the repository's test suite for this FastAPI template. The repo already contains workflow files in `.github/workflows/`, but the current setup needs to clearly enforce the template's core quality gates against the Python application in `src/backend`, related tests, and dependency configuration in `pyproject.toml`.

## Scope
- Review existing GitHub Actions definitions in `.github/workflows/pylint.yml`, `.github/workflows/python-app.yml`, and related workflow files to determine whether lint and test jobs are active, redundant, or incomplete.
- Implement a CI workflow strategy that runs on pull requests (and optionally pushes to `main` if already consistent with current repo patterns) and executes:
  - dependency/environment setup for the Python toolchain used by this repo
  - a lint step for the Python codebase
  - an automated test step for the existing test surface
- Ensure the workflow commands match the repository's actual developer setup defined in `pyproject.toml`, `uv.lock`, `README.md`, and any existing local task runners such as `Justfile` or pre-commit config.
- Verify the workflow covers the sample FastAPI backend areas under `src/backend` and the current test entry points, including files such as `src/backend/controller/appointment_controller_test.py` and any tests discoverable from the configured test runner.
- Update repository documentation if needed so contributors know which checks run in CI and how to run them locally.

## Acceptance Criteria
- A GitHub Actions workflow exists and is configured to trigger on pull requests targeting the main development branch.
- The workflow installs project dependencies using the repo's supported Python setup and succeeds without relying on undocumented manual environment preparation.
- The workflow runs a lint check against the Python codebase and fails the job when lint violations are present.
- The workflow runs the automated test suite and fails the job when tests fail.
- The implemented commands are consistent with repository configuration in `pyproject.toml` and documented local setup in `README.md`.
- Workflow definitions avoid unnecessary duplication with existing files in `.github/workflows/`; obsolete or overlapping CI workflow logic is consolidated if needed.
- Contributors can identify from the repo documentation or workflow names which checks are required for CI.

## Helpful Files
- `.github/workflows/pylint.yml`
- `.github/workflows/python-app.yml`
- `.github/workflows/makefile.yml`
- `.github/workflows/label.yml`
- `pyproject.toml`
- `README.md`
- `Justfile`
- `.pre-commit-config.yaml`
- `src/backend/controller/appointment_controller_test.py`
- `tests/__init__.py`

## Out of Scope
- Adding new product features to the FastAPI application.
- Expanding test coverage beyond what is necessary to make the CI test command runnable and reliable.
- Introducing deployment, release, or container publishing workflows.
- Reworking the backend architecture under `src/backend` outside of CI compatibility fixes.
- Adding non-Python quality gates unless they are already required by the repo's existing toolchain configuration.

## Codex Output
### Initial Draft
> Implemented the CI change by standardizing the repo on a single workflow in [`python-app.yml`](/job/repo/.github/workflows/python-app.yml). It now runs on pull requests to `main` and pushes to `main`, sets up Python from [`.python-version`](/job/repo/.python-version), installs `uv`, syncs locked dependencies, then runs `uv run ruff check .`, `uv run ty check`, and `uv run pytest`.
>
> I also remov...

## Validation
- `just lint`: passed
- `just test`: passed

## Push Warnings
- Berry opened this PR after a partial push fallback: GitHub rejected workflow file changes during push, so Berry retried without `.github/workflows/*` edits..
- Omitted workflow paths from the pushed branch: `.github/workflows/makefile.yml`, `.github/workflows/pylint.yml`, `.github/workflows/python-app.yml`
- Original branch `berry/codex-pr/BER-124-add-pull-request-ci-d4a60fcf` was retried as `berry/codex-pr/BER-124-add-pull-request-ci-d4a60fcf-partial`.

## Validation Repairs
### Repair Attempt 1 (`just lint`)
> The `just lint` failure was coming from `uv run ty check`, not the CI workflow YAML itself. I repaired the concrete typed-lint issues while leaving the ticket’s PR CI intent intact.
>
> Files changed for the repair:
> - [src/backend/controller/appointment_controller_test.py](/job/repo/src/backend/controller/appointment_controller_test.py)
> - [src/backend/gateway/appointment_gateway.py](/job/repo/src/...

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.pytest_cache`, `.ruff_cache`, `.venv`