### PR TITLE
BER-125: Consolidate Postgres DAO reads and writes under `src/backend/repository`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ This repository is a reusable Python/FastAPI template with a small document CRUD
 
 ## Sample Layout
 
-The template includes a lightweight frontend starter in `src/frontend` plus the existing document flow in `src/backend`:
+The template includes a lightweight frontend starter in `src/frontend` plus the existing sample workflows in `src/backend`:
 
 - `src/frontend`: Bun + Vite + TypeScript demo page for browser-facing starter work.
 - `src/backend/controller`: workflow orchestration plus input normalization for the sample document payload.
-- `src/backend/repository`: persistence helpers for `get`, `write` (create-or-update), and `delete`.
-- `src/backend/gateway`: connection-aware delegation into the repository layer.
+- `src/backend/repository`: canonical Postgres read/write helpers for the sample document and appointment CRUD flows.
+- `src/backend/gateway`: connection-aware delegation into the repository package rather than issuing SQL directly.
 - `src/backend/handlers`: request-payload translation plus a small sample artifact written during a successful document write.
 - `src/backend/db/postgres.py`: repository-owned Postgres bootstrap helpers and the adjacent `init-db.sql` schema used for the sample tables plus durable workflow state storage.
 
@@ -23,7 +23,7 @@ The default sample supports three basic operations:
 - `delete_document(document_id)`
 
 `write_document` uses create-or-update semantics so the same sample covers both initial creation and later replacement.
-The controller normalizes document ids and titles before delegating to the gateway and repository layers.
+The controller normalizes document ids and titles before delegating to the gateway and repository layers, and the same layering applies to the sample appointment flow.
 
 ## Frontend Demo
 
@@ -81,7 +81,8 @@ The checked-in `Dockerfile` and `docker-compose.yaml` continue to target the Fas
 
 The checked-in bootstrap script lives at `src/backend/db/init-db.sql`.
 It creates the sample `documents` and `appointments` tables expected by the repository layer, plus the durable workflow tables `workflow_state_store` and `workflow_state_transitions`.
-The adjacent `src/backend/db/postgres.py` module points to the bootstrap asset from the Python side without wiring new runtime behavior into the template.
+All workflow-specific Postgres CRUD reads and writes live in `src/backend/repository/document_repository.py` and `src/backend/repository/appointment_repository.py`.
+The adjacent `src/backend/db/postgres.py` module only points to the bootstrap asset from the Python side without owning sample-specific DAO behavior.
 
 Apply the schema to an existing local Postgres database with:
 
@@ -137,6 +138,7 @@ The main files to inspect while adapting the template are:
 - `src/backend/controller/document_controller_test.py`
 - `src/backend/controller/appointment_controller.py`
 - `src/backend/controller/appointment_controller_test.py`
+- `src/backend/repository/__init__.py`
 - `src/backend/repository/document_repository.py`
 - `src/backend/repository/appointment_repository.py`
 - `src/backend/gateway/document_gateway.py`

--- a/src/backend/db/postgres.py
+++ b/src/backend/db/postgres.py
@@ -1,4 +1,7 @@
-"""Postgres bootstrap helpers for repository-owned database assets."""
+"""Postgres bootstrap helpers for repository-owned database assets.
+
+Workflow-specific CRUD queries live under ``src.backend.repository``.
+"""
 
 from pathlib import Path
 

--- a/src/backend/db/postgres_test.py
+++ b/src/backend/db/postgres_test.py
@@ -1,5 +1,6 @@
 """Tests for repository-owned Postgres bootstrap assets."""
 
+import src.backend.db.postgres as postgres
 from src.backend.db.postgres import (
     BOOTSTRAP_SQL_PATH,
     BOOTSTRAP_TABLES,
@@ -13,3 +14,11 @@ def test_read_bootstrap_sql_loads_expected_tables() -> None:
     assert BOOTSTRAP_SQL_PATH.exists()
     for table_name in BOOTSTRAP_TABLES:
         assert f"CREATE TABLE IF NOT EXISTS {table_name}" in sql
+
+
+def test_postgres_module_only_exports_bootstrap_helpers() -> None:
+    assert postgres.__all__ == [
+        "BOOTSTRAP_SQL_PATH",
+        "BOOTSTRAP_TABLES",
+        "read_bootstrap_sql",
+    ]

--- a/src/backend/gateway/appointment_gateway.py
+++ b/src/backend/gateway/appointment_gateway.py
@@ -3,8 +3,8 @@
 from datetime import datetime
 from typing import Protocol, cast
 
-import src.backend.repository.appointment_repository as default_repository
-from src.backend.repository.appointment_repository import AppointmentConnection
+import src.backend.repository as default_repository
+from src.backend.repository import AppointmentConnection
 
 
 class AppointmentRepository(Protocol):

--- a/src/backend/gateway/document_gateway.py
+++ b/src/backend/gateway/document_gateway.py
@@ -2,8 +2,8 @@
 
 from typing import Protocol, cast
 
-import src.backend.repository.document_repository as default_repository
-from src.backend.repository.document_repository import DocumentConnection
+import src.backend.repository as default_repository
+from src.backend.repository import DocumentConnection
 
 
 class DocumentRepository(Protocol):

--- a/src/backend/repository/__init__.py
+++ b/src/backend/repository/__init__.py
@@ -1,0 +1,31 @@
+"""Canonical repository-layer exports for sample Postgres CRUD workflows."""
+
+from .appointment_repository import (
+    AppointmentConnection,
+    create_appointment,
+    delete_appointment,
+    get_appointment,
+    get_appointments,
+    has_conflict,
+    update_appointment,
+)
+from .document_repository import (
+    DocumentConnection,
+    delete_document,
+    get_document,
+    write_document,
+)
+
+__all__ = [
+    "AppointmentConnection",
+    "DocumentConnection",
+    "create_appointment",
+    "delete_appointment",
+    "delete_document",
+    "get_appointment",
+    "get_appointments",
+    "get_document",
+    "has_conflict",
+    "update_appointment",
+    "write_document",
+]

--- a/src/backend/repository/appointment_repository_test.py
+++ b/src/backend/repository/appointment_repository_test.py
@@ -1,0 +1,205 @@
+"""Tests for repository-owned appointment CRUD helpers."""
+
+import asyncio
+from datetime import datetime
+
+from src.backend import repository
+
+
+class StubAppointmentConnection:
+    def __init__(self) -> None:
+        self.execute_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.fetch_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.fetchrow_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.fetch_result: list[dict] = []
+        self.fetchrow_result: dict | None = None
+
+    async def execute(self, query: str, *args: object) -> object:
+        self.execute_calls.append((query, args))
+        return "DELETE 1"
+
+    async def fetch(self, query: str, *args: object) -> list[dict]:
+        self.fetch_calls.append((query, args))
+        return self.fetch_result
+
+    async def fetchrow(self, query: str, *args: object) -> dict | None:
+        self.fetchrow_calls.append((query, args))
+        return self.fetchrow_result
+
+
+def test_has_conflict_uses_repository_overlap_query() -> None:
+    conn = StubAppointmentConnection()
+    conn.fetch_result = [{"exists": 1}]
+    start_time = datetime(2026, 3, 21, 9, 0, 0)
+    end_time = datetime(2026, 3, 21, 10, 0, 0)
+
+    has_conflict = asyncio.run(repository.has_conflict(conn, start_time, end_time))
+
+    assert has_conflict is True
+    assert len(conn.fetch_calls) == 1
+    query, args = conn.fetch_calls[0]
+    assert "FROM appointments" in query
+    assert "start_time < $2 AND end_time > $1" in query
+    assert args == (start_time, end_time)
+
+
+def test_has_conflict_excludes_current_appointment_when_requested() -> None:
+    conn = StubAppointmentConnection()
+    conn.fetch_result = []
+    start_time = datetime(2026, 3, 21, 9, 0, 0)
+    end_time = datetime(2026, 3, 21, 10, 0, 0)
+
+    has_conflict = asyncio.run(
+        repository.has_conflict(
+            conn,
+            start_time,
+            end_time,
+            exclude_appointment_id=7,
+        )
+    )
+
+    assert has_conflict is False
+    assert len(conn.fetch_calls) == 1
+    query, args = conn.fetch_calls[0]
+    assert "id != $3" in query
+    assert args == (start_time, end_time, 7)
+
+
+def test_create_appointment_returns_normalized_row() -> None:
+    conn = StubAppointmentConnection()
+    start_time = datetime(2026, 3, 21, 9, 0, 0)
+    end_time = datetime(2026, 3, 21, 10, 0, 0)
+    conn.fetchrow_result = {
+        "id": 1,
+        "title": "Weekly sync",
+        "start_time": start_time,
+        "end_time": end_time,
+    }
+
+    appointment = asyncio.run(
+        repository.create_appointment(conn, "Weekly sync", start_time, end_time)
+    )
+
+    assert appointment == {
+        "id": 1,
+        "title": "Weekly sync",
+        "start_time": start_time,
+        "end_time": end_time,
+    }
+    assert len(conn.fetchrow_calls) == 1
+    query, args = conn.fetchrow_calls[0]
+    assert "INSERT INTO appointments" in query
+    assert "RETURNING id, title, start_time, end_time" in query
+    assert args == ("Weekly sync", start_time, end_time)
+
+
+def test_get_appointments_returns_normalized_rows() -> None:
+    conn = StubAppointmentConnection()
+    first_start_time = datetime(2026, 3, 21, 9, 0, 0)
+    first_end_time = datetime(2026, 3, 21, 10, 0, 0)
+    second_start_time = datetime(2026, 3, 21, 11, 0, 0)
+    second_end_time = datetime(2026, 3, 21, 12, 0, 0)
+    conn.fetch_result = [
+        {
+            "id": 1,
+            "title": "Weekly sync",
+            "start_time": first_start_time,
+            "end_time": first_end_time,
+        },
+        {
+            "id": 2,
+            "title": "Planning",
+            "start_time": second_start_time,
+            "end_time": second_end_time,
+        },
+    ]
+
+    appointments = asyncio.run(repository.get_appointments(conn))
+
+    assert appointments == [
+        {
+            "id": 1,
+            "title": "Weekly sync",
+            "start_time": first_start_time,
+            "end_time": first_end_time,
+        },
+        {
+            "id": 2,
+            "title": "Planning",
+            "start_time": second_start_time,
+            "end_time": second_end_time,
+        },
+    ]
+    assert len(conn.fetch_calls) == 1
+    query, args = conn.fetch_calls[0]
+    assert "SELECT id, title, start_time, end_time" in query
+    assert "ORDER BY start_time ASC" in query
+    assert args == ()
+
+
+def test_get_appointment_returns_normalized_row() -> None:
+    conn = StubAppointmentConnection()
+    start_time = datetime(2026, 3, 21, 9, 0, 0)
+    end_time = datetime(2026, 3, 21, 10, 0, 0)
+    conn.fetchrow_result = {
+        "id": 1,
+        "title": "Weekly sync",
+        "start_time": start_time,
+        "end_time": end_time,
+    }
+
+    appointment = asyncio.run(repository.get_appointment(conn, 1))
+
+    assert appointment == {
+        "id": 1,
+        "title": "Weekly sync",
+        "start_time": start_time,
+        "end_time": end_time,
+    }
+    assert len(conn.fetchrow_calls) == 1
+    query, args = conn.fetchrow_calls[0]
+    assert "SELECT id, title, start_time, end_time" in query
+    assert "WHERE id = $1" in query
+    assert args == (1,)
+
+
+def test_update_appointment_returns_normalized_row() -> None:
+    conn = StubAppointmentConnection()
+    start_time = datetime(2026, 3, 21, 9, 0, 0)
+    end_time = datetime(2026, 3, 21, 10, 0, 0)
+    conn.fetchrow_result = {
+        "id": 1,
+        "title": "Weekly sync",
+        "start_time": start_time,
+        "end_time": end_time,
+    }
+
+    appointment = asyncio.run(
+        repository.update_appointment(
+            conn,
+            1,
+            "Weekly sync",
+            start_time,
+            end_time,
+        )
+    )
+
+    assert appointment == {
+        "id": 1,
+        "title": "Weekly sync",
+        "start_time": start_time,
+        "end_time": end_time,
+    }
+    assert len(conn.fetchrow_calls) == 1
+    query, args = conn.fetchrow_calls[0]
+    assert "UPDATE appointments" in query
+    assert "WHERE id = $4" in query
+    assert args == ("Weekly sync", start_time, end_time, 1)
+
+
+def test_delete_appointment_uses_repository_delete_query() -> None:
+    conn = StubAppointmentConnection()
+
+    asyncio.run(repository.delete_appointment(conn, 1))
+
+    assert conn.execute_calls == [("DELETE FROM appointments WHERE id = $1", (1,))]

--- a/src/backend/repository/document_repository_test.py
+++ b/src/backend/repository/document_repository_test.py
@@ -1,0 +1,69 @@
+"""Tests for repository-owned document CRUD helpers."""
+
+import asyncio
+
+from src.backend import repository
+
+
+class StubDocumentConnection:
+    def __init__(self) -> None:
+        self.execute_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.fetchrow_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.fetchrow_result: dict | None = None
+
+    async def execute(self, query: str, *args: object) -> object:
+        self.execute_calls.append((query, args))
+        return "DELETE 1"
+
+    async def fetchrow(self, query: str, *args: object) -> dict | None:
+        self.fetchrow_calls.append((query, args))
+        return self.fetchrow_result
+
+
+def test_write_document_uses_repository_upsert_query() -> None:
+    conn = StubDocumentConnection()
+    conn.fetchrow_result = {
+        "id": "doc-123",
+        "title": "Example Title",
+        "content": "body",
+    }
+
+    document = asyncio.run(
+        repository.write_document(conn, "doc-123", "Example Title", "body")
+    )
+
+    assert document == {"id": "doc-123", "title": "Example Title", "content": "body"}
+    assert len(conn.fetchrow_calls) == 1
+    query, args = conn.fetchrow_calls[0]
+    assert "INSERT INTO documents" in query
+    assert "ON CONFLICT (id)" in query
+    assert "DO UPDATE SET title = EXCLUDED.title, content = EXCLUDED.content" in query
+    assert args == ("doc-123", "Example Title", "body")
+
+
+def test_get_document_returns_normalized_row() -> None:
+    conn = StubDocumentConnection()
+    conn.fetchrow_result = {
+        "id": "doc-123",
+        "title": "Example Title",
+        "content": "body",
+    }
+
+    document = asyncio.run(repository.get_document(conn, "doc-123"))
+
+    assert document == {"id": "doc-123", "title": "Example Title", "content": "body"}
+    assert len(conn.fetchrow_calls) == 1
+    query, args = conn.fetchrow_calls[0]
+    assert "SELECT id, title, content" in query
+    assert "FROM documents" in query
+    assert args == ("doc-123",)
+
+
+def test_delete_document_uses_repository_delete_query() -> None:
+    conn = StubDocumentConnection()
+
+    asyncio.run(repository.delete_document(conn, "doc-123"))
+
+    assert conn.execute_calls == [
+        ("DELETE FROM documents WHERE id = $1", ("doc-123",))
+    ]


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Linked Linear Ticket
Fixes BER-125
https://linear.app/baek/issue/BER-125/consolidate-postgres-dao-reads-and-writes-under-srcbackendrepository

## Instruction
Implement the approved Berry ticket: Consolidate Postgres DAO reads and writes under `src/backend/repository`.
Repository: https://github.com/bryanbaek/pypy
Base branch: main

Approved ticket description:
## Summary
Refactor the backend persistence boundaries so all Postgres DAO logic lives under `src/backend/repository`, consistent with the repository-layer contract described in `README.md`. Today, database read/write responsibilities appear to be split between repository helpers and lower-level Postgres/bootstrap surfaces, which makes the sample architecture less clear for template users and increases coupling across backend layers.

## Scope
- Audit current Postgres data-access code paths used by the sample document and adjacent backend workflows.
- Move or wrap direct Postgres read/write DAO operations so the canonical CRUD entrypoints are owned by `src/backend/repository`.
- Keep `src/backend/db/postgres.py` focused on connection/bootstrap/schema concerns rather than workflow-specific DAO behavior.
- Update callers in gateway/controller/handler layers to depend on repository functions instead of issuing direct Postgres-oriented operations outside the repository boundary.
- Preserve existing sample behavior for document CRUD flows and any tested appointment/document workflows affected by the refactor.
- Update README and any inline documentation that currently describes or implies a different layering model.

## Acceptance Criteria
- All workflow-specific Postgres create/read/update/delete operations are implemented in modules under `src/backend/repository`.
- `src/backend/db/postgres.py` only contains connection/bootstrap/schema utilities or generic database setup helpers, not sample-specific DAO methods.
- No controller, handler, or gateway module performs direct SQL execution or database read/write logic outside the repository layer.
- Existing document CRUD behavior remains unchanged from an API/workflow perspective after the refactor.
- Automated tests covering affected flows pass, and repository-focused tests are added or updated to validate the new persistence boundary.
- `README.md` reflects the final layering, including that repository owns persistence helpers and Postgres bootstrap remains in the db layer.

## Helpful Files
- `README.md`
- `src/backend/repository`
- `src/backend/db/postgres.py`
- `src/backend/gateway`
- `src/backend/controller/document_controller.py`
- `src/backend/controller/appointment_controller.py`
- `src/backend/controller/appointment_controller_test.py`
- `src/backend/handlers`

## Out of Scope
- Changing the database engine, schema design, or deployment/runtime infrastructure.
- Reworking frontend behavior in `src/frontend`.
- Introducing a new ORM or broad service-layer redesign beyond consolidating DAO ownership.
- Adding new product features beyond preserving current sample CRUD behavior during the refactor.

## Codex Output
### Initial Draft
> Repository CRUD ownership is now explicit at [src/backend/repository/__init__.py](/job/repo/src/backend/repository/__init__.py), which re-exports the sample document and appointment DAO entrypoints. Both gateways now depend on that package surface via [src/backend/gateway/document_gateway.py](/job/repo/src/backend/gateway/document_gateway.py) and [src/backend/gateway/appointment_gateway.py](/jo...

## Validation
- `just lint`: passed
- `just test`: passed

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.pytest_cache`, `.ruff_cache`, `.venv`