### PR TITLE
BER-126: Implement `src/backend/gateway/llm_gateway.py` with abstract LLM contract and OpenAI structured-output adapter

### DIFF
--- a/src/backend/gateway/README.md
+++ b/src/backend/gateway/README.md
@@ -10,7 +10,7 @@ Current integrations
 
 OpenAI gateway configuration
 - `OPENAI_API_KEY` (required)
-- `OPENAI_MODEL` (required by the gateway; repo defaults set this to `gpt-5.4-mini`)
+- `OPENAI_MODEL` (required)
 - `OPENAI_BASE_URL` (optional; for compatible endpoints)
 - `OPENAI_TIMEOUT_S` (default `30`)
 - `OPENAI_MAX_RETRIES` (default `2`)

--- a/src/backend/gateway/llm_gateway.py
+++ b/src/backend/gateway/llm_gateway.py
@@ -1,0 +1,233 @@
+"""LLM gateway abstractions and OpenAI structured-output implementation."""
+
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from collections.abc import Iterable, Mapping
+from typing import Any, TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+from src.backend.settings import OpenAISettings, get_openai_settings
+
+try:
+    from openai import AsyncOpenAI
+except ImportError:  # pragma: no cover - depends on local environment setup
+    AsyncOpenAI = None
+
+ResponseModelT = TypeVar("ResponseModelT", bound=BaseModel)
+
+
+class LLMGatewayError(RuntimeError):
+    """Base error for gateway-level LLM failures."""
+
+
+class LLMGatewayConfigurationError(LLMGatewayError):
+    """Raised when gateway configuration is incomplete or invalid."""
+
+
+class LLMOutputMissingError(LLMGatewayError):
+    """Raised when the provider response does not include text output."""
+
+
+class LLMOutputJSONError(LLMGatewayError):
+    """Raised when provider output is not valid JSON."""
+
+
+class LLMOutputValidationError(LLMGatewayError):
+    """Raised when provider JSON does not satisfy the response schema."""
+
+
+class LLMGateway(ABC):
+    """Abstract contract for structured LLM completions."""
+
+    @abstractmethod
+    async def structured_completion(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        response_model: type[ResponseModelT],
+    ) -> ResponseModelT:
+        """Return a validated structured response for the supplied prompts."""
+
+
+def _read_field(value: Any, key: str, default: Any = None) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(key, default)
+    return getattr(value, key, default)
+
+
+def _iter_items(value: Any) -> Iterable[Any]:
+    if value is None or isinstance(value, (str, bytes)):
+        return ()
+    if isinstance(value, Iterable):
+        return value
+    return ()
+
+
+def _normalize_json_schema(value: Any) -> Any:
+    if isinstance(value, dict):
+        normalized = {
+            key: _normalize_json_schema(item)
+            for key, item in value.items()
+        }
+        if normalized.get("type") == "object" and "additionalProperties" not in normalized:
+            normalized["additionalProperties"] = False
+        return normalized
+    if isinstance(value, list):
+        return [_normalize_json_schema(item) for item in value]
+    return value
+
+
+class OpenAILLMGateway(LLMGateway):
+    """OpenAI-backed LLM gateway for strict structured completions."""
+
+    def __init__(
+        self,
+        *,
+        settings: OpenAISettings | None = None,
+        client: Any | None = None,
+    ) -> None:
+        resolved_settings = get_openai_settings() if settings is None else settings
+        if not resolved_settings.model:
+            raise LLMGatewayConfigurationError(
+                "OPENAI_MODEL is required to initialize OpenAILLMGateway."
+            )
+        if client is None and not resolved_settings.api_key:
+            raise LLMGatewayConfigurationError(
+                "OPENAI_API_KEY is required to initialize OpenAILLMGateway "
+                "when no client is injected."
+            )
+        if client is None and AsyncOpenAI is None:
+            raise LLMGatewayConfigurationError(
+                "The openai package must be installed when no client is injected."
+            )
+
+        self._settings = resolved_settings
+        self.last_response_id: str | None = None
+        self._client = client if client is not None else self._build_client()
+
+    async def structured_completion(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        response_model: type[ResponseModelT],
+    ) -> ResponseModelT:
+        if not issubclass(response_model, BaseModel):
+            raise TypeError("response_model must be a Pydantic BaseModel type")
+
+        response = await self._client.responses.create(
+            model=self._settings.model,
+            input=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            text={"format": self._build_response_format(response_model)},
+        )
+        self.last_response_id = _read_field(response, "id")
+
+        output_text = self._extract_output_text(response)
+        payload = self._parse_json_payload(output_text, response_model)
+        return self._validate_payload(payload, response_model)
+
+    def _build_client(self) -> Any:
+        client_kwargs: dict[str, Any] = {
+            "api_key": self._settings.api_key,
+            "timeout": self._settings.timeout_s,
+            "max_retries": self._settings.max_retries,
+        }
+        if self._settings.base_url:
+            client_kwargs["base_url"] = self._settings.base_url
+        return AsyncOpenAI(**client_kwargs)
+
+    def _build_response_format(
+        self,
+        response_model: type[BaseModel],
+    ) -> dict[str, Any]:
+        return {
+            "type": "json_schema",
+            "name": self._schema_name(response_model),
+            "schema": self._build_response_schema(response_model),
+            "strict": True,
+        }
+
+    def _build_response_schema(
+        self,
+        response_model: type[BaseModel],
+    ) -> dict[str, Any]:
+        """Build the JSON schema sent to OpenAI for structured outputs."""
+        return _normalize_json_schema(response_model.model_json_schema())
+
+    def _schema_name(self, response_model: type[BaseModel]) -> str:
+        schema_name = response_model.__name__ or "structured_response"
+        sanitized = "".join(
+            character if character.isalnum() or character in {"_", "-"} else "_"
+            for character in schema_name
+        ).strip("_")
+        if not sanitized:
+            return "structured_response"
+        if sanitized[0].isdigit():
+            return f"schema_{sanitized}"
+        return sanitized
+
+    def _extract_output_text(self, response: Any) -> str:
+        output_text = _read_field(response, "output_text")
+        if isinstance(output_text, str) and output_text.strip():
+            return output_text
+
+        text_fragments: list[str] = []
+        for output_item in _iter_items(_read_field(response, "output")):
+            for content_item in _iter_items(_read_field(output_item, "content")):
+                if _read_field(content_item, "type") not in {"output_text", "text"}:
+                    continue
+                text_value = _read_field(content_item, "text")
+                if isinstance(text_value, str) and text_value:
+                    text_fragments.append(text_value)
+
+        aggregated_text = "".join(text_fragments)
+        if aggregated_text.strip():
+            return aggregated_text
+
+        raise LLMOutputMissingError(
+            "OpenAI response did not include any output text to parse."
+        )
+
+    def _parse_json_payload(
+        self,
+        output_text: str,
+        response_model: type[BaseModel],
+    ) -> Any:
+        try:
+            return json.loads(output_text)
+        except json.JSONDecodeError as exc:
+            raise LLMOutputJSONError(
+                f"OpenAI response for {response_model.__name__} was not valid JSON: "
+                f"{exc.msg} (line {exc.lineno}, column {exc.colno})."
+            ) from exc
+
+    def _validate_payload(
+        self,
+        payload: Any,
+        response_model: type[ResponseModelT],
+    ) -> ResponseModelT:
+        try:
+            return response_model.model_validate(payload)
+        except ValidationError as exc:
+            raise LLMOutputValidationError(
+                "OpenAI response JSON did not match the expected schema for "
+                f"{response_model.__name__}: {exc}"
+            ) from exc
+
+
+__all__ = [
+    "LLMGateway",
+    "LLMGatewayConfigurationError",
+    "LLMGatewayError",
+    "LLMOutputJSONError",
+    "LLMOutputMissingError",
+    "LLMOutputValidationError",
+    "OpenAILLMGateway",
+]

--- a/src/backend/gateway/llm_gateway_test.py
+++ b/src/backend/gateway/llm_gateway_test.py
@@ -1,0 +1,197 @@
+"""Tests for the OpenAI-backed structured LLM gateway."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from pydantic import BaseModel
+
+import src.backend.gateway.llm_gateway as llm_gateway_module
+from src.backend.gateway.llm_gateway import (
+    LLMGatewayConfigurationError,
+    LLMOutputJSONError,
+    LLMOutputMissingError,
+    LLMOutputValidationError,
+    OpenAILLMGateway,
+)
+from src.backend.settings import OpenAISettings
+
+
+class ExampleStructuredResponse(BaseModel):
+    answer: str
+    confidence: float
+
+
+class StubResponsesClient:
+    def __init__(self, response: object) -> None:
+        self._response = response
+        self.calls: list[dict[str, object]] = []
+
+    async def create(self, **kwargs: object) -> object:
+        self.calls.append(kwargs)
+        return self._response
+
+
+class StubOpenAIClient:
+    def __init__(self, response: object) -> None:
+        self.responses = StubResponsesClient(response)
+
+
+def test_openai_gateway_initializes_async_client_from_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_kwargs: dict[str, object] = {}
+
+    class FakeAsyncOpenAI:
+        def __init__(self, **kwargs: object) -> None:
+            captured_kwargs.update(kwargs)
+            self.responses = StubResponsesClient(SimpleNamespace())
+
+    monkeypatch.setattr(llm_gateway_module, "AsyncOpenAI", FakeAsyncOpenAI)
+
+    gateway = OpenAILLMGateway(
+        settings=OpenAISettings(
+            api_key="sk-test",
+            model="gpt-test",
+            base_url="https://example.com/v1",
+            timeout_s=12,
+            max_retries=4,
+        )
+    )
+
+    assert gateway.last_response_id is None
+    assert captured_kwargs == {
+        "api_key": "sk-test",
+        "base_url": "https://example.com/v1",
+        "timeout": 12.0,
+        "max_retries": 4,
+    }
+
+
+def test_openai_gateway_requires_model_configuration() -> None:
+    with pytest.raises(LLMGatewayConfigurationError, match="OPENAI_MODEL"):
+        OpenAILLMGateway(
+            settings=OpenAISettings(api_key="sk-test", model=None),
+            client=object(),
+        )
+
+
+def test_openai_gateway_requires_api_key_without_injected_client() -> None:
+    with pytest.raises(LLMGatewayConfigurationError, match="OPENAI_API_KEY"):
+        OpenAILLMGateway(settings=OpenAISettings(api_key=None, model="gpt-test"))
+
+
+def test_structured_completion_uses_schema_and_returns_validated_model() -> None:
+    response = SimpleNamespace(
+        id="resp_123",
+        output=[
+            SimpleNamespace(
+                content=[
+                    SimpleNamespace(
+                        type="output_text",
+                        text='{"answer": "42", "confidence": 0.9}',
+                    )
+                ]
+            )
+        ],
+    )
+    client = StubOpenAIClient(response)
+    gateway = OpenAILLMGateway(
+        settings=OpenAISettings(api_key=None, model="gpt-test"),
+        client=client,
+    )
+
+    result = asyncio.run(
+        gateway.structured_completion(
+            system_prompt="Return structured data only.",
+            user_prompt="What is the answer?",
+            response_model=ExampleStructuredResponse,
+        )
+    )
+
+    assert result == ExampleStructuredResponse(answer="42", confidence=0.9)
+    assert gateway.last_response_id == "resp_123"
+
+    request = client.responses.calls[0]
+    assert request["model"] == "gpt-test"
+    assert request["input"] == [
+        {"role": "system", "content": "Return structured data only."},
+        {"role": "user", "content": "What is the answer?"},
+    ]
+    assert request["text"]["format"]["type"] == "json_schema"
+    assert request["text"]["format"]["name"] == "ExampleStructuredResponse"
+    assert request["text"]["format"]["strict"] is True
+    assert (
+        request["text"]["format"]["schema"]["properties"]
+        == ExampleStructuredResponse.model_json_schema()["properties"]
+    )
+    assert (
+        request["text"]["format"]["schema"]["required"]
+        == ExampleStructuredResponse.model_json_schema()["required"]
+    )
+
+
+def test_structured_completion_rejects_invalid_json() -> None:
+    client = StubOpenAIClient(
+        SimpleNamespace(
+            id="resp_bad_json",
+            output_text='{"answer": "42", "confidence": 0.9',
+        )
+    )
+    gateway = OpenAILLMGateway(
+        settings=OpenAISettings(api_key=None, model="gpt-test"),
+        client=client,
+    )
+
+    with pytest.raises(LLMOutputJSONError, match="not valid JSON"):
+        asyncio.run(
+            gateway.structured_completion(
+                system_prompt="Return structured data only.",
+                user_prompt="What is the answer?",
+                response_model=ExampleStructuredResponse,
+            )
+        )
+
+
+def test_structured_completion_rejects_schema_invalid_json() -> None:
+    client = StubOpenAIClient(
+        SimpleNamespace(
+            id="resp_bad_schema",
+            output_text='{"answer": "42"}',
+        )
+    )
+    gateway = OpenAILLMGateway(
+        settings=OpenAISettings(api_key=None, model="gpt-test"),
+        client=client,
+    )
+
+    with pytest.raises(LLMOutputValidationError, match="expected schema"):
+        asyncio.run(
+            gateway.structured_completion(
+                system_prompt="Return structured data only.",
+                user_prompt="What is the answer?",
+                response_model=ExampleStructuredResponse,
+            )
+        )
+
+
+def test_structured_completion_rejects_missing_output_text() -> None:
+    client = StubOpenAIClient(
+        SimpleNamespace(
+            id="resp_no_text",
+            output=[SimpleNamespace(content=[SimpleNamespace(type="refusal")])],
+        )
+    )
+    gateway = OpenAILLMGateway(
+        settings=OpenAISettings(api_key=None, model="gpt-test"),
+        client=client,
+    )
+
+    with pytest.raises(LLMOutputMissingError, match="did not include any output text"):
+        asyncio.run(
+            gateway.structured_completion(
+                system_prompt="Return structured data only.",
+                user_prompt="What is the answer?",
+                response_model=ExampleStructuredResponse,
+            )
+        )

--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -1,0 +1,72 @@
+"""Environment-backed runtime settings for backend integrations."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+from pydantic import BaseModel, ConfigDict, Field
+
+DEFAULT_OPENAI_TIMEOUT_S = 30.0
+DEFAULT_OPENAI_MAX_RETRIES = 2
+
+
+def _read_optional_env(
+    environ: Mapping[str, str],
+    key: str,
+    *,
+    default: str | float | int | None = None,
+) -> str | float | int | None:
+    value = environ.get(key)
+    if value is None:
+        return default
+
+    normalized = value.strip()
+    if not normalized:
+        return default
+    return normalized
+
+
+class OpenAISettings(BaseModel):
+    """Configuration required by the OpenAI-backed LLM gateway."""
+
+    model_config = ConfigDict(frozen=True)
+
+    api_key: str | None = None
+    model: str | None = None
+    base_url: str | None = None
+    timeout_s: float = Field(default=DEFAULT_OPENAI_TIMEOUT_S, gt=0)
+    max_retries: int = Field(default=DEFAULT_OPENAI_MAX_RETRIES, ge=0)
+
+    @classmethod
+    def from_env(cls, environ: Mapping[str, str] | None = None) -> "OpenAISettings":
+        """Build OpenAI settings from environment variables."""
+        source = os.environ if environ is None else environ
+        return cls(
+            api_key=_read_optional_env(source, "OPENAI_API_KEY"),
+            model=_read_optional_env(source, "OPENAI_MODEL"),
+            base_url=_read_optional_env(source, "OPENAI_BASE_URL"),
+            timeout_s=_read_optional_env(
+                source,
+                "OPENAI_TIMEOUT_S",
+                default=DEFAULT_OPENAI_TIMEOUT_S,
+            ),
+            max_retries=_read_optional_env(
+                source,
+                "OPENAI_MAX_RETRIES",
+                default=DEFAULT_OPENAI_MAX_RETRIES,
+            ),
+        )
+
+
+def get_openai_settings(environ: Mapping[str, str] | None = None) -> OpenAISettings:
+    """Return the repository's OpenAI settings object."""
+    return OpenAISettings.from_env(environ)
+
+
+__all__ = [
+    "DEFAULT_OPENAI_MAX_RETRIES",
+    "DEFAULT_OPENAI_TIMEOUT_S",
+    "OpenAISettings",
+    "get_openai_settings",
+]


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Linked Linear Ticket
Fixes BER-126
https://linear.app/baek/issue/BER-126/implement-srcbackendgatewayllm-gatewaypy-with-abstract-llm-contract

## Instruction
Implement the approved Berry ticket: Implement `src/backend/gateway/llm_gateway.py` with abstract LLM contract and OpenAI structured-output adapter.
Repository: https://github.com/bryanbaek/pypy
Base branch: main

Approved ticket description:
## Summary
Add a new backend gateway module for LLM access that fits the repository's existing controller/gateway layering. The module should define an abstract `LLMGateway` interface for structured completions and a concrete `OpenAILLMGateway` implementation backed by the OpenAI async client. The implementation should support strict JSON-schema-based responses validated into Pydantic models, provider configuration via settings/environment variables, and clear error handling when the model output is missing, invalid JSON, or schema-invalid.

## Scope
- Create `src/backend/gateway/llm_gateway.py`.
- Define an abstract `LLMGateway(ABC)` with an async `structured_completion(...)` contract that accepts `system_prompt`, `user_prompt`, and a Pydantic `response_model` and returns a validated `BaseModel` instance.
- Define OpenAI-specific settings using the repository's settings pattern so configuration is sourced from environment variables such as `OPENAI_API_KEY`, `OPENAI_MODEL`, optional `OPENAI_BASE_URL`, timeout, and retry settings.
- Implement `OpenAILLMGateway(LLMGateway)` using `openai.AsyncOpenAI` and the Responses API with strict JSON schema output.
- Ensure the gateway builds the schema from `response_model.model_json_schema()` by default, while allowing explicit special handling for known repo-specific response envelopes if needed by surrounding PM-tool workflows.
- Add response text extraction logic for OpenAI Responses API payloads and raise actionable errors when output text is absent.
- Parse returned JSON and validate it via `response_model.model_validate(...)`.
- Add focused tests for initialization, schema-driven structured completion, invalid JSON handling, invalid schema handling, and missing output text.
- Wire any required dependency additions/config updates in `pyproject.toml` if OpenAI SDK support is not already declared.

## Acceptance Criteria
- `src/backend/gateway/llm_gateway.py` exists and exports `LLMGateway` and `OpenAILLMGateway`.
- `LLMGateway` is an abstract base class with an async `structured_completion` method returning structured Pydantic output rather than raw text.
- `OpenAILLMGateway` reads configuration through the repo settings pattern and rejects missing required model configuration; it must also reject missing API key when no injected client is provided.
- `OpenAILLMGateway.structured_completion(...)` sends system and user prompts through `AsyncOpenAI().responses.create(...)` using strict JSON schema formatting derived from the requested response model.
- Successful responses are converted from provider output text into JSON and validated into the requested Pydantic model before being returned.
- The implementation records the last OpenAI response id on the gateway instance for observability/debugging.
- Missing response text raises a clear error.
- Invalid JSON from the provider raises a clear error.
- Schema-invalid JSON from the provider raises a clear error.
- Tests cover the main happy path plus the three failure modes above without requiring live OpenAI network calls.
- The implementation stays within the backend gateway/settings layer and does not add frontend changes.

## Helpful Files
- `README.md`
- `pyproject.toml`
- `src/backend/gateway/README.md`
- `src/backend/controller/README.md`
- `src/backend/handlers/README.md`
- Existing backend settings module referenced by current code conventions (for example `src/backend/settings.py` if present)
- `src/backend/controller/appointment_controller.py`
- `src/backend/controller/appointment_controller_test.py`

## Out of Scope
- Building end-user LLM product features or UI flows.
- Integrating the new gateway into controllers, handlers, or PM-tool orchestration beyond what is needed to define the reusable gateway module itself.
- Supporting non-OpenAI providers in this ticket.
- Prompt library design, workflow state machine changes, or new persistence behavior.
- Live end-to-end tests against the OpenAI API.

## Codex Output
### Initial Draft
> Implemented the requested backend gateway change.
>
> - [llm_gateway.py](/job/repo/src/backend/gateway/llm_gateway.py): added the abstract `LLMGateway`, concrete `OpenAILLMGateway`, strict schema-based `structured_completion(...)`, response-id tracking, and clear failures for missing output text, invalid JSON, and schema-invalid payloads.
> - [settings.py](/job/repo/src/backend/settings.py): added t...

## Validation
- `just lint`: warning
- `just test`: passed

## Validation Warnings
- Berry opened this PR with `PR_DRAFT_VALIDATION_MODE=warn_only`.
- local validation warnings did not block PR opening.
- `just lint` new local validation failures: Object of type `None` is not assignable to `<class 'AsyncOpenAI'>` (src/backend/gateway/llm_gateway.py:17:5), Cannot subscript object of type `object` with no `__getitem__` method (src/backend/gateway/llm_gateway_test.py:121:12), Argument is incorrect (src/backend/settings.py:46:13)

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.pytest_cache`, `.ruff_cache`, `.venv`