### PR TITLE
BER-127: Update docker-compose to run frontend with persisted Postgres and env.example-backed configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,6 @@ uv run uvicorn src.backend.main:app --reload
 
 The included FastAPI app starts from `src/backend/main.py`.
 
-To run the same backend application in Docker:
-
-```bash
-docker compose up --build
-```
-
 ### Frontend
 
 The frontend starter uses Bun as its package manager/runtime. After installing Bun locally, install frontend dependencies from the repo root:
@@ -64,7 +58,7 @@ cd src/frontend
 bun run dev
 ```
 
-Then open `http://localhost:5173` in a browser. The demo page includes quick links to the FastAPI sample on `http://localhost:8000`, but the frontend starter runs as a separate dev server so it does not change the backend document example.
+Then open `http://localhost:5173` in a browser. The demo page links to the FastAPI sample using `VITE_BACKEND_URL`, which defaults to `http://localhost:8000` for local development.
 
 Create a production build with:
 
@@ -75,7 +69,28 @@ bun run build
 
 The built assets are written to `src/frontend/dist/`.
 
-The checked-in `Dockerfile` and `docker-compose.yaml` continue to target the FastAPI app only; the frontend demo is intentionally a local Bun/Vite workflow.
+### Docker Compose
+
+For the full local stack, copy `env.example` to `.env`, adjust any ports or database credentials you need, and then start the services:
+
+```bash
+cp env.example .env
+docker compose up --build
+```
+
+By default, the compose stack exposes:
+
+- FastAPI on `http://localhost:8000`
+- Bun/Vite frontend on `http://localhost:5173`
+- Postgres on `localhost:5432`
+
+`docker-compose.yaml` reads its local database and app settings from the variables you copied from `env.example` into `.env`, including `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `BACKEND_PORT`, `FRONTEND_PORT`, and `VITE_BACKEND_URL`.
+The frontend service runs the existing app in `src/frontend`, the backend service continues to run `src.backend.main:app`, and the Postgres service mounts the bootstrap SQL from `src/backend/db/init-db.sql`.
+If you change the published backend URL, update `VITE_BACKEND_URL` so the frontend demo links still point at the FastAPI service.
+
+The Postgres data directory lives in the named `postgres-data` volume.
+That means `docker compose stop`, `docker compose start`, and `docker compose down` preserve your sample document data, appointment data, and workflow state.
+Run `docker compose down -v` only when you want to remove the named volume and force Postgres to initialize a fresh database on the next `docker compose up`.
 
 ## Postgres Bootstrap
 
@@ -84,29 +99,15 @@ It creates the sample `documents` and `appointments` tables expected by the repo
 All workflow-specific Postgres CRUD reads and writes live in `src/backend/repository/document_repository.py` and `src/backend/repository/appointment_repository.py`.
 The adjacent `src/backend/db/postgres.py` module only points to the bootstrap asset from the Python side without owning sample-specific DAO behavior.
 
+When you start the compose stack, `docker-compose.yaml` mounts that same SQL file into the official Postgres entrypoint directory at `/docker-entrypoint-initdb.d/init-db.sql`.
+The official Postgres image applies files from that directory only when it initializes a fresh data directory, so the named `postgres-data` volume preserves both schema and data across container recreation.
+If you need the bootstrap script to run again after changing the schema, remove the volume with `docker compose down -v` before starting the stack again.
+
 Apply the schema to an existing local Postgres database with:
 
 ```bash
 psql "$DATABASE_URL" -f src/backend/db/init-db.sql
 ```
-
-For Docker-based startup, mount the same file into the official Postgres entrypoint directory.
-The current `docker-compose.yaml` only starts the FastAPI app, so add a Postgres service with a volume such as:
-
-```yaml
-services:
-  postgres:
-    image: postgres:16
-    environment:
-      POSTGRES_DB: pypy
-      POSTGRES_USER: pypy
-      POSTGRES_PASSWORD: pypy
-    volumes:
-      - ./src/backend/db/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql:ro
-```
-
-The official Postgres image applies files in `/docker-entrypoint-initdb.d/` only when it initializes a fresh data directory.
-If you are reusing an existing local volume, rerun the `psql` command above instead.
 
 ## Verify
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,71 @@
 services:
+  postgres:
+    image: postgres:16
+    command: ["postgres", "-p", "${POSTGRES_PORT}"]
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      PGPORT: ${POSTGRES_PORT}
+    ports:
+      - "${POSTGRES_PORT}:${POSTGRES_PORT}"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -h 127.0.0.1 -p ${POSTGRES_PORT} -U ${POSTGRES_USER} -d ${POSTGRES_DB}",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./src/backend/db/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql:ro
+    networks:
+      default:
+        aliases:
+          - ${POSTGRES_HOST}
+
   pypy-app:
     build:
       context: .
       dockerfile: Dockerfile
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+      ENVIRONMENT: ${ENVIRONMENT}
+      DEBUG: ${DEBUG}
+      LOG_LEVEL: ${LOG_LEVEL}
+      SECRET_KEY: ${SECRET_KEY}
+      POSTGRES_HOST: ${POSTGRES_HOST}
+      POSTGRES_PORT: ${POSTGRES_PORT}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
-      - "8000:8000"
+      - "${BACKEND_PORT}:8000"
+
+  frontend:
+    image: oven/bun:1.1
+    working_dir: /app
+    depends_on:
+      pypy-app:
+        condition: service_started
+    environment:
+      VITE_BACKEND_URL: ${VITE_BACKEND_URL}
+    volumes:
+      - ./src/frontend:/app
+    command:
+      [
+        "sh",
+        "-c",
+        "bun install && bun run dev -- --host 0.0.0.0 --port 5173",
+      ]
+    ports:
+      - "${FRONTEND_PORT}:5173"
+
+volumes:
+  postgres-data:

--- a/env.example
+++ b/env.example
@@ -1,13 +1,25 @@
+# Copy this file to .env before running docker compose locally.
+
 # API Keys (required for AI features)
 OPENAI_API_KEY=your_openai_api_key_here
 GOOGLE_API_KEY=your_google_api_key_here
 GROQ_API_KEY=your_groq_api_key_here
 
 # Database Configuration
-DATABASE_URL=
-POSTGRES_DB=
-POSTGRES_USER=
-POSTGRES_PASSWORD=
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_DB=pypy
+POSTGRES_USER=pypy
+POSTGRES_PASSWORD=pypy
+# Optional host-side connection string for tools outside docker compose.
+# If you change the published Postgres settings above, update this URL to match.
+DATABASE_URL=postgresql://pypy:pypy@localhost:5432/pypy
+
+# Local Container Ports
+BACKEND_PORT=8000
+FRONTEND_PORT=5173
+# Update this if you change the published backend URL.
+VITE_BACKEND_URL=http://localhost:8000
 
 # Redis Configuration
 REDIS_URL=redis://:redis_password@redis:6379/0

--- a/src/backend/gateway/llm_gateway.py
+++ b/src/backend/gateway/llm_gateway.py
@@ -11,10 +11,13 @@ from pydantic import BaseModel, ValidationError
 
 from src.backend.settings import OpenAISettings, get_openai_settings
 
+AsyncOpenAI: Any | None
 try:
-    from openai import AsyncOpenAI
+    from openai import AsyncOpenAI as _AsyncOpenAI
 except ImportError:  # pragma: no cover - depends on local environment setup
     AsyncOpenAI = None
+else:
+    AsyncOpenAI = _AsyncOpenAI
 
 ResponseModelT = TypeVar("ResponseModelT", bound=BaseModel)
 
@@ -134,6 +137,10 @@ class OpenAILLMGateway(LLMGateway):
         return self._validate_payload(payload, response_model)
 
     def _build_client(self) -> Any:
+        if AsyncOpenAI is None:  # pragma: no cover - guarded in __init__
+            raise LLMGatewayConfigurationError(
+                "The openai package must be installed when no client is injected."
+            )
         client_kwargs: dict[str, Any] = {
             "api_key": self._settings.api_key,
             "timeout": self._settings.timeout_s,

--- a/src/backend/gateway/llm_gateway_test.py
+++ b/src/backend/gateway/llm_gateway_test.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from pydantic import BaseModel
@@ -25,9 +26,9 @@ class ExampleStructuredResponse(BaseModel):
 class StubResponsesClient:
     def __init__(self, response: object) -> None:
         self._response = response
-        self.calls: list[dict[str, object]] = []
+        self.calls: list[dict[str, Any]] = []
 
-    async def create(self, **kwargs: object) -> object:
+    async def create(self, **kwargs: Any) -> object:
         self.calls.append(kwargs)
         return self._response
 

--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -42,20 +42,22 @@ class OpenAISettings(BaseModel):
     def from_env(cls, environ: Mapping[str, str] | None = None) -> "OpenAISettings":
         """Build OpenAI settings from environment variables."""
         source = os.environ if environ is None else environ
-        return cls(
-            api_key=_read_optional_env(source, "OPENAI_API_KEY"),
-            model=_read_optional_env(source, "OPENAI_MODEL"),
-            base_url=_read_optional_env(source, "OPENAI_BASE_URL"),
-            timeout_s=_read_optional_env(
-                source,
-                "OPENAI_TIMEOUT_S",
-                default=DEFAULT_OPENAI_TIMEOUT_S,
-            ),
-            max_retries=_read_optional_env(
-                source,
-                "OPENAI_MAX_RETRIES",
-                default=DEFAULT_OPENAI_MAX_RETRIES,
-            ),
+        return cls.model_validate(
+            {
+                "api_key": _read_optional_env(source, "OPENAI_API_KEY"),
+                "model": _read_optional_env(source, "OPENAI_MODEL"),
+                "base_url": _read_optional_env(source, "OPENAI_BASE_URL"),
+                "timeout_s": _read_optional_env(
+                    source,
+                    "OPENAI_TIMEOUT_S",
+                    default=DEFAULT_OPENAI_TIMEOUT_S,
+                ),
+                "max_retries": _read_optional_env(
+                    source,
+                    "OPENAI_MAX_RETRIES",
+                    default=DEFAULT_OPENAI_MAX_RETRIES,
+                ),
+            }
         )
 
 

--- a/src/frontend/src/main.ts
+++ b/src/frontend/src/main.ts
@@ -1,6 +1,11 @@
 import "./style.css";
 
 const app = document.querySelector<HTMLDivElement>("#app");
+const defaultBackendUrl = "http://localhost:8000";
+const configuredBackendUrl = import.meta.env.VITE_BACKEND_URL ?? defaultBackendUrl;
+const backendUrl = configuredBackendUrl.endsWith("/")
+    ? configuredBackendUrl.slice(0, -1)
+    : configuredBackendUrl;
 
 if (!app) {
     throw new Error("Frontend app root was not found.");
@@ -17,10 +22,10 @@ app.innerHTML = `
         <code>src/frontend</code> as a lightweight starting point for UI work.
       </p>
       <div class="hero-actions">
-        <a href="http://localhost:8000/" target="_blank" rel="noreferrer">
+        <a href="${backendUrl}/" target="_blank" rel="noreferrer">
           Open FastAPI sample
         </a>
-        <a href="http://localhost:8000/health" target="_blank" rel="noreferrer">
+        <a href="${backendUrl}/health" target="_blank" rel="noreferrer">
           Check backend health
         </a>
       </div>

--- a/src/frontend/src/vite-env.d.ts
+++ b/src/frontend/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    readonly VITE_BACKEND_URL?: string;
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Linked Linear Ticket
Fixes BER-127
https://linear.app/baek/issue/BER-127/update-docker-compose-to-run-frontend-with-persisted-postgres-and

## Instruction
Implement the approved Berry ticket: Update docker-compose to run frontend with persisted Postgres and env.example-backed configuration.
Repository: https://github.com/bryanbaek/pypy
Base branch: main

Approved ticket description:
## Summary
Update the local container workflow so `docker-compose.yaml` reflects the full starter template described in `README.md`: a FastAPI backend, the Bun/Vite frontend in `src/frontend`, and Postgres with durable data persistence. The compose setup should read configurable values from `env.example`-documented environment variables instead of hardcoding connection details, and the repo documentation should explain how to start the stack and preserve database state across restarts.

## Scope
- Modify `docker-compose.yaml` to include the frontend service alongside the existing backend/database workflow.
- Add a named Postgres volume so sample document/appointment data and workflow state survive container recreation.
- Wire compose environment configuration to variables documented in `env.example` for database/app settings that are currently implicit or hardcoded.
- Ensure the backend service configuration remains aligned with the sample architecture in `README.md`, including use of the Postgres bootstrap path under `src/backend/db/postgres.py` and related schema initialization behavior.
- Update `README.md` and/or `env.example` so local setup instructions match the revised compose workflow.

## Acceptance Criteria
- `docker-compose.yaml` defines a Postgres service with persistent storage via a named volume rather than ephemeral container-only storage.
- `docker-compose.yaml` defines a frontend service using the app in `src/frontend` and exposes the expected dev-facing port(s) for local use.
- Backend, frontend, and Postgres services share configuration through environment variables sourced from values documented in `env.example`.
- No required database host, port, username, password, or database name values remain silently hardcoded in compose when they should be user-configurable.
- The documented local startup flow in `README.md` matches the compose file and explains how persistence behaves across `docker compose down` / restart cycles.
- The change stays within local development orchestration and does not require altering GitHub Actions workflows such as `.github/workflows/python-app.yml` or `.github/workflows/makefile.yml`.

## Helpful Files
- `docker-compose.yaml`
- `env.example`
- `README.md`
- `Dockerfile`
- `src/frontend/package.json`
- `src/backend/db/postgres.py`
- `nginx/nginx.conf`

## Out of Scope
- Refactoring backend controller/repository business logic in `src/backend/controller` or `src/backend/repository`.
- Production deployment hardening, Kubernetes, or cloud infrastructure changes.
- Reworking CI pipelines in `.github/workflows`.
- Adding new frontend product features beyond making the existing starter runnable in compose.
- Changing database schema or CRUD semantics beyond what is needed to support local startup with persistent storage.

## Codex Output
### Initial Draft
> Implemented the local stack update so compose now includes persisted Postgres, the Bun/Vite frontend, and env-driven configuration.
>
> Changed files:
> - [docker-compose.yaml](/job/repo/docker-compose.yaml): added `postgres` with a named `postgres-data` volume, mounted `src/backend/db/init-db.sql`, wired backend DB/app settings from env vars, and added a frontend service for `src/frontend`.
> - [env....

## Validation
- `just lint`: passed
- `just test`: passed

## Validation Repairs
### Repair Attempt 1 (`just lint`)
> Repaired the `just lint` failure in the `ty check` phase by tightening the three flagged backend files: [src/backend/gateway/llm_gateway.py](/job/repo/src/backend/gateway/llm_gateway.py), [src/backend/gateway/llm_gateway_test.py](/job/repo/src/backend/gateway/llm_gateway_test.py), and [src/backend/settings.py](/job/repo/src/backend/settings.py). The fix keeps the original compose/frontend ticke...

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.pytest_cache`, `.ruff_cache`, `.venv`