### PR TITLE
BER-130: Add a template-readiness checklist and validation workflow for repo bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,3 @@ venv/
 
 # VS Code configuration directory
 .vscode/
-
-# Github configuration directory
-.github/

--- a/README.md
+++ b/README.md
@@ -1,64 +1,110 @@
 # FastAPI Template
 
-This repository is a reusable Python/FastAPI template with a small document CRUD sample. The default example is intentionally domain-neutral so you can copy the layer boundaries without inheriting business-specific rules. A minimal Bun + Vite + TypeScript frontend starter also lives alongside the backend so the template includes a simple browser-facing demo surface.
+This repository is a reusable FastAPI template with a small set of starter examples. The checked-in document and appointment flows are intentionally sample code, not required product logic. A lightweight Bun + Vite + TypeScript page in `src/frontend` is included for browser-facing bootstrap work.
 
-## Sample Layout
+## Before Using This As A Template
 
-The template includes a lightweight frontend starter in `src/frontend` plus the existing sample workflows in `src/backend`:
+Use the starter code as a verification target before you replace it with your own domain:
 
-- `src/frontend`: Bun + Vite + TypeScript demo page for browser-facing starter work.
-- `src/backend/controller`: workflow orchestration plus input normalization for the sample document payload.
-- `src/backend/repository`: canonical Postgres read/write helpers for the sample document and appointment CRUD flows.
-- `src/backend/gateway`: connection-aware delegation into the repository package rather than issuing SQL directly.
-- `src/backend/handlers`: request-payload translation plus a small sample artifact written during a successful document write.
-- `src/backend/db/postgres.py`: repository-owned Postgres bootstrap helpers and the adjacent `init-db.sql` schema used for the sample tables plus durable workflow state storage.
+1. Review the starter surfaces you plan to keep versus replace.
 
+- Keep the layer boundaries in `src/backend/controller`, `src/backend/gateway`, `src/backend/repository`, and `src/backend/handlers`.
+- Treat the sample document and appointment flows in those directories as starter examples.
+- Treat `src/frontend` as an optional demo UI that proves the backend/frontend wiring, not as required long-term product code.
 
-## Sample Operations
+2. Copy the example environment file and decide which integrations still belong in your project.
 
-The default sample supports three basic operations:
+```bash
+cp env.example .env
+```
 
-- `get_document(document_id)`
-- `write_document(document_id, title, content)`
-- `delete_document(document_id)`
+- `docker-compose.yaml` and the local Postgres bootstrap rely on `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `DATABASE_URL`, `BACKEND_PORT`, `FRONTEND_PORT`, and `VITE_BACKEND_URL`.
+- If you keep the optional OpenAI starter integration in `src/backend/gateway/llm_gateway.py`, also set `OPENAI_API_KEY` and `OPENAI_MODEL`.
 
-`write_document` uses create-or-update semantics so the same sample covers both initial creation and later replacement.
-The controller normalizes document ids and titles before delegating to the gateway and repository layers, and the same layering applies to the sample appointment flow.
+3. Verify the template before you customize it.
+
+```bash
+uv sync
+cd src/frontend
+bun install
+cd ../..
+docker compose up --build
+just lint
+just test
+```
+
+- `uv sync` installs the backend toolchain declared in `pyproject.toml`.
+- `bun install`, `bun run dev`, and `bun run build` come from `src/frontend/package.json`.
+- The `Template Readiness` GitHub Actions workflow runs the same `uv sync`, `just lint`, and `just test` entrypoints on pull requests to `main` and via manual dispatch.
+
+4. Replace starter examples only after the repository is green.
+
+- Swap the sample document and appointment modules for your own domain behavior while keeping the layer seams.
+- Update `src/frontend/src/main.ts` after your own backend routes and URLs are in place.
+- Keep `src/backend/main.py` minimal until you decide which product routes should actually be mounted by default.
+
+## Starter Layout
+
+The template includes a lightweight frontend starter in `src/frontend` plus starter backend layers in `src/backend`:
+
+- `src/frontend`: Bun + Vite + TypeScript demo page. Optional starter UI.
+- `src/backend/controller`: sample document and appointment orchestration. Keep the controller boundary, replace the sample rules.
+- `src/backend/gateway`: outbound integrations. `llm_gateway.py` is an optional starter integration, not a mandatory runtime dependency.
+- `src/backend/repository`: Postgres read/write helpers for the sample document and appointment flows.
+- `src/backend/handlers`: thin request/response helpers around the sample flows.
+- `src/backend/db/postgres.py`: bootstrap helpers for checked-in database assets.
+- `src/backend/db/init-db.sql`: sample tables plus durable workflow-state tables used by local Postgres bootstrap.
+
+The default FastAPI app in `src/backend/main.py` only mounts `/` and `/health`. The document and appointment CRUD modules are starter examples that are unit tested in place, but they are not wired into live routes until you choose how to expose them.
+
+## Starter Examples
+
+The sample backend includes two small starter flows:
+
+- Document CRUD example: `src/backend/controller/document_controller.py`, `src/backend/handlers/document_handlers.py`, and `src/backend/repository/document_repository.py`
+- Appointment CRUD example: `src/backend/controller/appointment_controller.py`, `src/backend/handlers/appointment_handlers.py`, and `src/backend/repository/appointment_repository.py`
+
+`write_document` keeps create-or-update semantics so a single starter flow covers both initial creation and replacement. The appointment sample shows payload normalization, time-range validation, and conflict checks.
 
 ## Frontend Demo
 
-The frontend sample lives in `src/frontend`. It is intentionally lightweight and domain-neutral: a single Bun + Vite + TypeScript page that gives contributors a concrete place to start UI work without replacing the existing FastAPI document workflow.
+The frontend starter lives in `src/frontend`. It is intentionally small: a single Bun + Vite + TypeScript page that links to the FastAPI root and health endpoints. Replace it after the template bootstrap checks pass and your own product routes exist.
 
 ## Run
 
 ### Backend
 
-Install backend dependencies with your preferred Python toolchain. If you use `uv`:
+Install backend dependencies from the repo root with:
 
 ```bash
 uv sync
+```
+
+Start the FastAPI app with:
+
+```bash
 uv run uvicorn src.backend.main:app --reload
 ```
 
-The included FastAPI app starts from `src/backend/main.py`.
+The included FastAPI app starts from `src/backend/main.py` and exposes `/` plus `/health`.
 
 ### Frontend
 
-The frontend starter uses Bun as its package manager/runtime. After installing Bun locally, install frontend dependencies from the repo root:
+The frontend starter uses Bun. Install dependencies from the repo root with:
 
 ```bash
 cd src/frontend
 bun install
 ```
 
-Start the Vite development server:
+Start the Vite development server with:
 
 ```bash
 cd src/frontend
 bun run dev
 ```
 
-Then open `http://localhost:5173` in a browser. The demo page links to the FastAPI sample using `VITE_BACKEND_URL`, which defaults to `http://localhost:8000` for local development.
+Then open `http://localhost:5173` in a browser. The demo page links to the FastAPI starter using `VITE_BACKEND_URL`, which defaults to `http://localhost:8000` for local development.
 
 Create a production build with:
 
@@ -71,7 +117,7 @@ The built assets are written to `src/frontend/dist/`.
 
 ### Docker Compose
 
-For the full local stack, copy `env.example` to `.env`, adjust any ports or database credentials you need, and then start the services:
+For the full local stack, copy `env.example` to `.env`, adjust any ports or credentials you need, and then start the services:
 
 ```bash
 cp env.example .env
@@ -84,23 +130,23 @@ By default, the compose stack exposes:
 - Bun/Vite frontend on `http://localhost:5173`
 - Postgres on `localhost:5432`
 
-`docker-compose.yaml` reads its local database and app settings from the variables you copied from `env.example` into `.env`, including `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `BACKEND_PORT`, `FRONTEND_PORT`, and `VITE_BACKEND_URL`.
-The frontend service runs the existing app in `src/frontend`, the backend service continues to run `src.backend.main:app`, and the Postgres service mounts the bootstrap SQL from `src/backend/db/init-db.sql`.
-If you change the published backend URL, update `VITE_BACKEND_URL` so the frontend demo links still point at the FastAPI service.
+`docker-compose.yaml` reads its local database and app settings from the variables copied from `env.example` into `.env`, including `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `BACKEND_PORT`, `FRONTEND_PORT`, and `VITE_BACKEND_URL`.
+
+The frontend service runs the starter app in `src/frontend`, the backend service runs `src.backend.main:app`, and the Postgres service mounts the bootstrap SQL from `src/backend/db/init-db.sql`.
+If you change the published backend URL, update `VITE_BACKEND_URL` so the frontend starter still points at the FastAPI service.
 
 The Postgres data directory lives in the named `postgres-data` volume.
-That means `docker compose stop`, `docker compose start`, and `docker compose down` preserve your sample document data, appointment data, and workflow state.
+That means `docker compose stop`, `docker compose start`, and `docker compose down` preserve starter document data, appointment data, and workflow state.
 Run `docker compose down -v` only when you want to remove the named volume and force Postgres to initialize a fresh database on the next `docker compose up`.
 
 ## Postgres Bootstrap
 
 The checked-in bootstrap script lives at `src/backend/db/init-db.sql`.
-It creates the sample `documents` and `appointments` tables expected by the repository layer, plus the durable workflow tables `workflow_state_store` and `workflow_state_transitions`.
-All workflow-specific Postgres CRUD reads and writes live in `src/backend/repository/document_repository.py` and `src/backend/repository/appointment_repository.py`.
-The adjacent `src/backend/db/postgres.py` module only points to the bootstrap asset from the Python side without owning sample-specific DAO behavior.
+It creates the sample `documents` and `appointments` tables expected by the starter repository modules, plus the durable workflow tables `workflow_state_store` and `workflow_state_transitions`.
+The Python helper in `src/backend/db/postgres.py` only reads that bootstrap asset; it does not own sample-specific query logic.
 
-When you start the compose stack, `docker-compose.yaml` mounts that same SQL file into the official Postgres entrypoint directory at `/docker-entrypoint-initdb.d/init-db.sql`.
-The official Postgres image applies files from that directory only when it initializes a fresh data directory, so the named `postgres-data` volume preserves both schema and data across container recreation.
+When you start the compose stack, `docker-compose.yaml` mounts that SQL file into the official Postgres entrypoint directory at `/docker-entrypoint-initdb.d/init-db.sql`.
+The Postgres image applies files from that directory only when it initializes a fresh data directory, so the named `postgres-data` volume preserves both schema and data across container recreation.
 If you need the bootstrap script to run again after changing the schema, remove the volume with `docker compose down -v` before starting the stack again.
 
 Apply the schema to an existing local Postgres database with:
@@ -119,36 +165,34 @@ just test
 ```
 
 `just lint` runs `uv run ruff check .` followed by `uv run ty check`.
-`just test` runs `uv run pytest`, which includes colocated `*_test.py` modules under `src/`.
-Pull requests to `main` and pushes to `main` run the same lint and test commands in GitHub Actions.
+`just test` runs `uv run pytest`, which includes colocated `*_test.py` modules under `src/` plus any tests under `tests/`.
+
+The `Template Readiness` GitHub Actions workflow runs `uv sync`, `just lint`, and `just test` on pull requests to `main` and via manual dispatch. That workflow also validates that this README, `Justfile`, `pyproject.toml`, `docker-compose.yaml`, `env.example`, and the backend layer README files stay aligned.
 
 ## Development
 
-For repo checks during development, use `just lint` and `just test` after `uv sync`.
+Use these files first while adapting the template:
 
-The main files to inspect while adapting the template are:
-
-- `src/frontend/package.json`
-- `src/frontend/index.html`
-- `src/frontend/src/main.ts`
-- `src/frontend/src/style.css`
 - `src/backend/main.py`
-- `src/backend/db/postgres.py`
-- `src/backend/db/init-db.sql`
+- `src/backend/main_test.py`
+- `src/backend/controller/README.md`
 - `src/backend/controller/document_controller.py`
-- `src/backend/controller/document_controller_test.py`
 - `src/backend/controller/appointment_controller.py`
-- `src/backend/controller/appointment_controller_test.py`
-- `src/backend/repository/__init__.py`
-- `src/backend/repository/document_repository.py`
-- `src/backend/repository/appointment_repository.py`
-- `src/backend/gateway/document_gateway.py`
-- `src/backend/gateway/appointment_gateway.py`
+- `src/backend/gateway/README.md`
+- `src/backend/gateway/llm_gateway.py`
+- `src/backend/handlers/README.md`
 - `src/backend/handlers/document_handlers.py`
 - `src/backend/handlers/appointment_handlers.py`
-- `src/backend/main_test.py`
+- `src/backend/repository/README.md`
+- `src/backend/repository/document_repository.py`
+- `src/backend/repository/appointment_repository.py`
+- `src/backend/db/postgres.py`
+- `src/backend/db/init-db.sql`
+- `src/frontend/package.json`
+- `src/frontend/src/main.ts`
+- `src/frontend/src/style.css`
 
 ## Notes
 
-- The sample is deliberately small and not production-ready.
-- The repository still includes infrastructure scaffolding such as Docker, GitHub Actions, and FastAPI app wiring so you can build on top of the template.
+- The sample flows are deliberately small and are meant to be replaced.
+- The repository keeps Docker, GitHub Actions, FastAPI app wiring, and starter tests so new projects can bootstrap from a working baseline.

--- a/env.example
+++ b/env.example
@@ -2,6 +2,7 @@
 
 # API Keys (required for AI features)
 OPENAI_API_KEY=your_openai_api_key_here
+OPENAI_MODEL=your_openai_model_here
 GOOGLE_API_KEY=your_google_api_key_here
 GROQ_API_KEY=your_groq_api_key_here
 

--- a/src/backend/controller/README.md
+++ b/src/backend/controller/README.md
@@ -1,0 +1,10 @@
+Controller layer (workflow orchestration)
+
+Purpose
+- Normalize input and enforce workflow rules before touching I/O.
+- Keep controllers reusable and deterministic by delegating external work to collaborators.
+
+Starter surfaces in this template
+- `document_controller.py` — sample document CRUD orchestration that shows required-field normalization and create-or-update behavior.
+- `appointment_controller.py` — sample appointment orchestration that shows validation and conflict checks.
+- Both files are starter examples. Keep the controller boundary, but replace the document and appointment rules when you adapt the template to a real product.

--- a/src/backend/gateway/README.md
+++ b/src/backend/gateway/README.md
@@ -1,23 +1,22 @@
 Gateway layer (outbound integrations)
 
 Purpose
-- Encapsulate all calls to third-party services so controllers stay deterministic and testable.
+- Encapsulate calls to third-party services so controllers stay deterministic and testable.
 - Provide small, typed facades that can be mocked in unit tests.
 
-Current integrations
-- `llm_gateway.py` — abstract interface and OpenAI-backed implementation for structured LLM completions (`structured_completion`) returning Pydantic models. The OpenAI gateway enforces strict JSON output using the supplied Pydantic schema and fails closed on validation errors; no raw text parsing.
-
+Starter surfaces in this template
+- `llm_gateway.py` — optional OpenAI-backed starter integration for structured outputs.
+- This repository does not require the gateway layer to be active for local bootstrap. Keep it only if your project still needs LLM access.
 
 OpenAI gateway configuration
-- `OPENAI_API_KEY` (required)
-- `OPENAI_MODEL` (required)
+- `OPENAI_API_KEY` (required when using the OpenAI-backed gateway)
+- `OPENAI_MODEL` (required when using the OpenAI-backed gateway)
 - `OPENAI_BASE_URL` (optional; for compatible endpoints)
 - `OPENAI_TIMEOUT_S` (default `30`)
 - `OPENAI_MAX_RETRIES` (default `2`)
 
-
 Guidelines
 - Keep APIs minimal and explicit; no global clients.
 - Return structured results or raise domain-specific exceptions; avoid leaking provider-specific objects upward.
-- Make timeouts/configuration injectable; prefer dependency injection in controllers/services.
-- Ensure gateways are side-effect focused only (no business logic).
+- Make timeouts and configuration injectable; prefer dependency injection in controllers and services.
+- Ensure gateways stay side-effect focused only and do not absorb business logic.

--- a/src/backend/handlers/README.md
+++ b/src/backend/handlers/README.md
@@ -1,7 +1,10 @@
-Handlers layer (FastAPI routes)
+Handlers layer (request/response translation)
 
 Purpose
-- Thin HTTP layer: parse/validate requests, call controllers, shape responses.
-- No business logic or direct DB mutations.
+- Keep the HTTP or transport-facing layer thin: parse requests, call controllers, and shape responses.
+- Avoid business logic and direct database mutations in handlers.
 
-Primary runtime endpoints
+Starter surfaces in this template
+- `document_handlers.py` — sample document CRUD payload translation plus a starter artifact write on successful document updates.
+- `appointment_handlers.py` — sample appointment payload parsing and response shaping.
+- These files are starter examples. They are not mounted by default in `src/backend/main.py`, so you can replace them with product-specific routes without first unwinding live runtime wiring.

--- a/src/backend/repository/README.md
+++ b/src/backend/repository/README.md
@@ -1,12 +1,14 @@
 Repository layer (data access)
 
 Purpose
-- DAO helpers for persistence; no business logic.
-- Functions operate on open connections / transactions and return typed models.
+- Keep persistence access in one place and out of controllers and handlers.
+- Operate on open connections or transactions and return typed data structures.
 
-Datastore layout
-- `postgres/` — one module per table plus shared test helpers
-- `schema.sql` — authoritative schema mirrored by `scripts/init-db.sql`
+Starter surfaces in this template
+- `document_repository.py` — sample persistence helpers for the starter `documents` table.
+- `appointment_repository.py` — sample persistence helpers for the starter `appointments` table.
+- `src/backend/db/init-db.sql` — compose bootstrap schema for the sample CRUD tables plus durable workflow-state tables.
+- The document and appointment tables are starter examples. Keep the repository boundary, but replace the sample tables and queries when you adapt the template to your own domain.
 
 Notes
-- There is no active Redis repository layer in the primary runtime.
+- There is no active Redis or Chroma repository layer in the checked-in runtime.

--- a/tests/template_readiness_test.py
+++ b/tests/template_readiness_test.py
@@ -1,0 +1,175 @@
+"""Template-readiness checks for bootstrap documentation and entrypoints."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def _assert_contains_all(contents: str, expected_snippets: tuple[str, ...], *, label: str) -> None:
+    missing = [snippet for snippet in expected_snippets if snippet not in contents]
+    assert not missing, f"{label} is missing expected snippets: {missing}"
+
+
+def _read_env_keys(relative_path: str) -> set[str]:
+    keys: set[str] = set()
+    for raw_line in _read(relative_path).splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _ = line.split("=", 1)
+        keys.add(key)
+    return keys
+
+
+def test_readme_documents_template_bootstrap_flow() -> None:
+    readme = _read("README.md")
+
+    _assert_contains_all(
+        readme,
+        (
+            "## Before Using This As A Template",
+            "`src/backend/controller`",
+            "`src/backend/gateway`",
+            "`src/backend/repository`",
+            "`src/backend/handlers`",
+            "`src/frontend`",
+            "`env.example`",
+            "`docker-compose.yaml`",
+            "`uv sync`",
+            "`just lint`",
+            "`just test`",
+            "`bun install`",
+            "`bun run dev`",
+            "`bun run build`",
+            "`docker compose up --build`",
+            "starter examples",
+            "only mounts `/` and `/health`",
+        ),
+        label="README.md",
+    )
+
+
+def test_template_readiness_workflow_runs_documented_entrypoints() -> None:
+    workflow = _read(".github/workflows/template-readiness.yml")
+
+    _assert_contains_all(
+        workflow,
+        (
+            "name: Template Readiness",
+            "pull_request:",
+            'branches: ["main"]',
+            "workflow_dispatch:",
+            'python-version: "3.12"',
+            "uv sync",
+            "just lint",
+            "just test",
+        ),
+        label=".github/workflows/template-readiness.yml",
+    )
+
+
+def test_root_entrypoints_match_documented_commands() -> None:
+    justfile = _read("Justfile")
+    pyproject = _read("pyproject.toml")
+    frontend_package = _read("src/frontend/package.json")
+
+    _assert_contains_all(
+        justfile,
+        (
+            "lint:",
+            "uv run ruff check .",
+            "uv run ty check",
+            "test:",
+            "uv run pytest",
+        ),
+        label="Justfile",
+    )
+    _assert_contains_all(
+        pyproject,
+        (
+            'requires-python = ">=3.12"',
+            'testpaths = ["src", "tests"]',
+        ),
+        label="pyproject.toml",
+    )
+    _assert_contains_all(
+        frontend_package,
+        (
+            '"dev": "vite"',
+            '"build": "tsc --noEmit && vite build"',
+            '"preview": "vite preview"',
+        ),
+        label="src/frontend/package.json",
+    )
+
+
+def test_env_example_and_compose_cover_bootstrap_configuration() -> None:
+    env_keys = _read_env_keys("env.example")
+    docker_compose = _read("docker-compose.yaml")
+
+    assert {
+        "OPENAI_API_KEY",
+        "OPENAI_MODEL",
+        "POSTGRES_HOST",
+        "POSTGRES_PORT",
+        "POSTGRES_DB",
+        "POSTGRES_USER",
+        "POSTGRES_PASSWORD",
+        "DATABASE_URL",
+        "BACKEND_PORT",
+        "FRONTEND_PORT",
+        "VITE_BACKEND_URL",
+    }.issubset(env_keys)
+
+    _assert_contains_all(
+        docker_compose,
+        (
+            "${POSTGRES_HOST}",
+            "${POSTGRES_PORT}",
+            "${POSTGRES_DB}",
+            "${POSTGRES_USER}",
+            "${POSTGRES_PASSWORD}",
+            "${BACKEND_PORT}",
+            "${FRONTEND_PORT}",
+            "${VITE_BACKEND_URL}",
+            "./src/backend/db/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql:ro",
+        ),
+        label="docker-compose.yaml",
+    )
+
+
+def test_backend_layer_readmes_identify_starter_surfaces() -> None:
+    layer_docs = {
+        "src/backend/controller/README.md": (
+            "starter examples",
+            "document_controller.py",
+            "appointment_controller.py",
+        ),
+        "src/backend/gateway/README.md": (
+            "optional",
+            "llm_gateway.py",
+            "OPENAI_MODEL",
+        ),
+        "src/backend/handlers/README.md": (
+            "starter examples",
+            "document_handlers.py",
+            "appointment_handlers.py",
+            "not mounted by default",
+        ),
+        "src/backend/repository/README.md": (
+            "starter examples",
+            "document_repository.py",
+            "appointment_repository.py",
+            "src/backend/db/init-db.sql",
+        ),
+    }
+
+    for relative_path, expected_snippets in layer_docs.items():
+        contents = _read(relative_path)
+        assert contents.strip(), f"{relative_path} should not be empty"
+        _assert_contains_all(contents, expected_snippets, label=relative_path)


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Linked Linear Ticket
Fixes BER-130
https://linear.app/baek/issue/BER-130/add-a-template-readiness-checklist-and-validation-workflow-for-repo

## Instruction
Implement the approved Berry ticket: Add a template-readiness checklist and validation workflow for repo bootstrap.
Repository: https://github.com/bryanbaek/pypy
Base branch: main

Approved ticket description:
## Summary
Add a single template-readiness workflow so this FastAPI template can be confidently reused for new projects without carrying over sample-specific assumptions. The work should define a documented bootstrap checklist in `README.md`, add automation that validates core template expectations in GitHub Actions, and make the sample backend/frontend surfaces clearly identifiable as starter code rather than required product logic.

## Scope
- Document a concise "before using this as a template" bootstrap flow in `README.md` aligned to the current architecture described for `src/backend/controller`, `src/backend/gateway`, `src/backend/repository`, `src/backend/handlers`, and `src/frontend`.
- Add a repository validation workflow under `.github/workflows` that checks template-critical items such as local setup commands, lint/test entrypoints, required example environment configuration, and presence of starter documentation.
- Ensure root-level developer entrypoints (`Justfile`, `pyproject.toml`, `docker-compose.yaml`, `env.example`) are referenced consistently in docs and automation so a new consumer can verify the template works before customization.
- Clarify which included sample surfaces are optional starter examples versus expected long-term project structure, especially around sample CRUD flows and frontend demo assets.

## Acceptance Criteria
- `README.md` includes a clearly labeled section describing the recommended steps to take before cloning or adapting the repo for a new project.
- The documented bootstrap flow references the existing stack and repo surfaces actually present in this codebase, including backend sample layers, frontend starter, environment setup, and CI expectations.
- A GitHub Actions workflow is added or updated to run a template-readiness validation on pull requests and/or manual execution.
- The validation fails when required template artifacts are missing or when documented setup/test commands drift from the repository's current entrypoints.
- Root developer workflows are consistent across documentation and automation, with no conflicting setup commands between `README.md`, workflow files in `.github/workflows`, and project config files.
- The ticket does not require replacing the sample CRUD implementation with a new domain; it only improves confidence and readiness for downstream reuse.

## Helpful Files
- `README.md`
- `.github/workflows/python-app.yml`
- `.github/workflows/pylint.yml`
- `.github/workflows/makefile.yml`
- `Justfile`
- `pyproject.toml`
- `docker-compose.yaml`
- `env.example`
- `src/backend/controller/README.md`
- `src/backend/gateway/README.md`
- `src/backend/handlers/README.md`
- `src/backend/repository/README.md`
- `src/frontend/package.json`

## Out of Scope
- Re-architecting the backend layer boundaries or replacing the sample document/appointment flows.
- Building a full project generator, CLI scaffolder, or cookiecutter-style template engine.
- Expanding product features in the frontend demo beyond what is needed to explain starter behavior.
- Broad CI/CD redesign unrelated to template-readiness validation.

## Codex Output
### Initial Draft
> **Changed**
>
> - [README.md](/job/repo/README.md) now has a clearly labeled “Before Using This As A Template” checklist, aligns the bootstrap steps to the current repo entrypoints, and explicitly marks the document/appointment code plus `src/frontend` as starter surfaces rather than required product logic.
> - [src/backend/controller/README.md](/job/repo/src/backend/controller/README.md), [src/back...

## Validation
- `just lint`: passed
- `just test`: warning

## Validation Warnings
- Berry opened this PR with `PR_DRAFT_VALIDATION_MODE=warn_only`.
- local validation warnings did not block PR opening.
- `just test` new local validation failures: E AssertionError: README.md is missing expected snippets: ['`docker compose up --build`'], tests/template_readiness_test.py:15: AssertionError, Recipe `test` failed on line 6 with exit code 1

## Push Warnings
- Berry opened this PR after a partial push fallback: GitHub rejected workflow file changes during push, so Berry retried without `.github/workflows/*` edits..
- Omitted workflow paths from the pushed branch: `.github/workflows/makefile.yml`, `.github/workflows/pylint.yml`, `.github/workflows/python-app.yml`, `.github/workflows/template-readiness.yml`
- Original branch `berry/codex-pr/BER-130-add-a-template-readiness-d7cfd732` was retried as `berry/codex-pr/BER-130-add-a-template-readiness-d7cfd732-partial`.

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.pytest_cache`, `.ruff_cache`, `.venv`