### PR TITLE
BER-131: Add job detail and resume routes under src/backend/handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,28 +41,29 @@ just test
 
 - Swap the sample document and appointment modules for your own domain behavior while keeping the layer seams.
 - Update `src/frontend/src/main.ts` after your own backend routes and URLs are in place.
-- Keep `src/backend/main.py` minimal until you decide which product routes should actually be mounted by default.
+- Keep `src/backend/main.py` minimal beyond the mounted sample job workflow routes until you decide which product routes should actually be mounted by default.
 
 ## Starter Layout
 
 The template includes a lightweight frontend starter in `src/frontend` plus starter backend layers in `src/backend`:
 
 - `src/frontend`: Bun + Vite + TypeScript demo page. Optional starter UI.
-- `src/backend/controller`: sample document and appointment orchestration. Keep the controller boundary, replace the sample rules.
+- `src/backend/controller`: sample document, appointment, and job orchestration. Keep the controller boundary, replace the sample rules.
 - `src/backend/gateway`: outbound integrations. `llm_gateway.py` is an optional starter integration, not a mandatory runtime dependency.
 - `src/backend/repository`: Postgres read/write helpers for the sample document and appointment flows.
-- `src/backend/handlers`: thin request/response helpers around the sample flows.
+- `src/backend/handlers`: thin request/response helpers around the sample flows plus a mounted sample job workflow router.
 - `src/backend/db/postgres.py`: bootstrap helpers for checked-in database assets.
 - `src/backend/db/init-db.sql`: sample tables plus durable workflow-state tables used by local Postgres bootstrap.
 
-The default FastAPI app in `src/backend/main.py` only mounts `/` and `/health`. The document and appointment CRUD modules are starter examples that are unit tested in place, but they are not wired into live routes until you choose how to expose them.
+The default FastAPI app in `src/backend/main.py` mounts `/`, `/health`, `/jobs/{job_id}/detail`, and `/jobs/{job_id}/resume`. The document and appointment CRUD modules are starter examples that are unit tested in place, but they are not wired into live routes until you choose how to expose them.
 
 ## Starter Examples
 
-The sample backend includes two small starter flows:
+The sample backend includes three small starter flows:
 
 - Document CRUD example: `src/backend/controller/document_controller.py`, `src/backend/handlers/document_handlers.py`, and `src/backend/repository/document_repository.py`
 - Appointment CRUD example: `src/backend/controller/appointment_controller.py`, `src/backend/handlers/appointment_handlers.py`, and `src/backend/repository/appointment_repository.py`
+- Job workflow example: `src/backend/controller/job_controller.py` and `src/backend/handlers/job_handlers.py`
 
 `write_document` keeps create-or-update semantics so a single starter flow covers both initial creation and replacement. The appointment sample shows payload normalization, time-range validation, and conflict checks.
 
@@ -86,7 +87,7 @@ Start the FastAPI app with:
 uv run uvicorn src.backend.main:app --reload
 ```
 
-The included FastAPI app starts from `src/backend/main.py` and exposes `/` plus `/health`.
+The included FastAPI app starts from `src/backend/main.py` and exposes `/`, `/health`, `/jobs/{job_id}/detail`, and `/jobs/{job_id}/resume`.
 
 ### Frontend
 
@@ -178,11 +179,13 @@ Use these files first while adapting the template:
 - `src/backend/controller/README.md`
 - `src/backend/controller/document_controller.py`
 - `src/backend/controller/appointment_controller.py`
+- `src/backend/controller/job_controller.py`
 - `src/backend/gateway/README.md`
 - `src/backend/gateway/llm_gateway.py`
 - `src/backend/handlers/README.md`
 - `src/backend/handlers/document_handlers.py`
 - `src/backend/handlers/appointment_handlers.py`
+- `src/backend/handlers/job_handlers.py`
 - `src/backend/repository/README.md`
 - `src/backend/repository/document_repository.py`
 - `src/backend/repository/appointment_repository.py`

--- a/src/backend/controller/README.md
+++ b/src/backend/controller/README.md
@@ -7,4 +7,5 @@ Purpose
 Starter surfaces in this template
 - `document_controller.py` — sample document CRUD orchestration that shows required-field normalization and create-or-update behavior.
 - `appointment_controller.py` — sample appointment orchestration that shows validation and conflict checks.
-- Both files are starter examples. Keep the controller boundary, but replace the document and appointment rules when you adapt the template to a real product.
+- `job_controller.py` — sample workflow job orchestration that shows identifier normalization, typed detail retrieval, and explicit resume rules.
+- Keep the controller boundary, but replace the sample document, appointment, and job rules when you adapt the template to a real product.

--- a/src/backend/controller/job_controller.py
+++ b/src/backend/controller/job_controller.py
@@ -1,0 +1,142 @@
+"""Controller layer coordinating the sample job workflow routes."""
+
+from typing import Protocol
+
+from src.backend.models.job import JobDetailDTO
+
+
+class InvalidJobIdError(ValueError):
+    """Raised when a provided job id is blank after normalization."""
+
+
+class JobNotFoundError(ValueError):
+    """Raised when a requested job does not exist."""
+
+
+class JobNotResumableError(ValueError):
+    """Raised when a job cannot be resumed from its current state."""
+
+
+def _normalize_job_id(job_id: str) -> str:
+    normalized_job_id = job_id.strip()
+    if not normalized_job_id:
+        raise InvalidJobIdError("job_id must not be empty")
+    return normalized_job_id
+
+
+def _can_resume(status: str) -> bool:
+    return status in {"paused", "in_progress"}
+
+
+class JobGatewayContract(Protocol):
+    """Gateway contract used by job controller orchestration."""
+
+    async def get_job(self, job_id: str) -> JobDetailDTO | None: ...
+
+    async def save_job(self, job: JobDetailDTO) -> JobDetailDTO: ...
+
+
+class InMemoryJobGateway:
+    """Small in-memory gateway used by the sample job workflow routes."""
+
+    def __init__(self, jobs: dict[str, JobDetailDTO]) -> None:
+        self._jobs = {
+            job_id: job.model_copy(deep=True)
+            for job_id, job in jobs.items()
+        }
+
+    async def get_job(self, job_id: str) -> JobDetailDTO | None:
+        job = self._jobs.get(job_id)
+        if job is None:
+            return None
+        return job.model_copy(deep=True)
+
+    async def save_job(self, job: JobDetailDTO) -> JobDetailDTO:
+        self._jobs[job.job_id] = job.model_copy(deep=True)
+        return self._jobs[job.job_id].model_copy(deep=True)
+
+
+def _default_jobs() -> dict[str, JobDetailDTO]:
+    return {
+        "job-paused-123": JobDetailDTO(
+            job_id="job-paused-123",
+            workflow_type="pm_tool_workflow",
+            current_state="awaiting_requirements",
+            status="paused",
+            state_version=3,
+            resume_count=0,
+            can_resume=True,
+            last_error="Waiting for product requirements",
+        ),
+        "job-running-456": JobDetailDTO(
+            job_id="job-running-456",
+            workflow_type="pm_tool_workflow",
+            current_state="drafting_pr",
+            status="in_progress",
+            state_version=5,
+            resume_count=1,
+            can_resume=True,
+        ),
+        "job-completed-789": JobDetailDTO(
+            job_id="job-completed-789",
+            workflow_type="pm_tool_workflow",
+            current_state="published_summary",
+            status="completed",
+            state_version=8,
+            resume_count=0,
+            can_resume=False,
+        ),
+    }
+
+
+class JobController:
+    """Application workflow service for the sample job routes."""
+
+    def __init__(self, gateway: JobGatewayContract) -> None:
+        self._gateway = gateway
+
+    async def get_job_detail(self, job_id: str) -> JobDetailDTO:
+        normalized_job_id = _normalize_job_id(job_id)
+        job = await self._gateway.get_job(normalized_job_id)
+        if job is None:
+            raise JobNotFoundError("job not found")
+        return job
+
+    async def resume_job(self, job_id: str) -> JobDetailDTO:
+        job = await self.get_job_detail(job_id)
+        if not _can_resume(job.status):
+            raise JobNotResumableError(
+                f"job is not resumable from status '{job.status}'"
+            )
+
+        resumed_job = job.model_copy(
+            update={
+                "current_state": (
+                    "drafting_pr"
+                    if job.status == "paused"
+                    else job.current_state
+                ),
+                "status": "in_progress",
+                "state_version": job.state_version + 1,
+                "resume_count": job.resume_count + 1,
+                "can_resume": True,
+                "last_error": None,
+            }
+        )
+        return await self._gateway.save_job(resumed_job)
+
+
+def build_job_controller() -> JobController:
+    """Build the sample controller used by mounted job handlers."""
+    return JobController(InMemoryJobGateway(_default_jobs()))
+
+
+__all__ = [
+    "InMemoryJobGateway",
+    "InvalidJobIdError",
+    "JobController",
+    "JobGatewayContract",
+    "JobNotFoundError",
+    "JobNotResumableError",
+    "build_job_controller",
+]

--- a/src/backend/controller/job_controller_test.py
+++ b/src/backend/controller/job_controller_test.py
@@ -1,0 +1,122 @@
+"""Tests for sample job workflow orchestration."""
+
+import asyncio
+
+import pytest
+
+from src.backend.controller.job_controller import (
+    InvalidJobIdError,
+    JobController,
+    JobNotFoundError,
+    JobNotResumableError,
+)
+from src.backend.models.job import JobDetailDTO
+
+
+class StubJobGateway:
+    def __init__(self) -> None:
+        self.jobs = {
+            "job-paused-123": JobDetailDTO(
+                job_id="job-paused-123",
+                workflow_type="pm_tool_workflow",
+                current_state="awaiting_requirements",
+                status="paused",
+                state_version=3,
+                resume_count=0,
+                can_resume=True,
+                last_error="Waiting for product requirements",
+            ),
+            "job-completed-789": JobDetailDTO(
+                job_id="job-completed-789",
+                workflow_type="pm_tool_workflow",
+                current_state="published_summary",
+                status="completed",
+                state_version=8,
+                resume_count=0,
+                can_resume=False,
+            ),
+            "job-running-456": JobDetailDTO(
+                job_id="job-running-456",
+                workflow_type="pm_tool_workflow",
+                current_state="drafting_pr",
+                status="in_progress",
+                state_version=5,
+                resume_count=1,
+                can_resume=True,
+            ),
+        }
+        self.requested_ids: list[str] = []
+        self.saved_jobs: list[JobDetailDTO] = []
+
+    async def get_job(self, job_id: str) -> JobDetailDTO | None:
+        self.requested_ids.append(job_id)
+        job = self.jobs.get(job_id)
+        if job is None:
+            return None
+        return job.model_copy(deep=True)
+
+    async def save_job(self, job: JobDetailDTO) -> JobDetailDTO:
+        self.saved_jobs.append(job.model_copy(deep=True))
+        self.jobs[job.job_id] = job.model_copy(deep=True)
+        return job.model_copy(deep=True)
+
+
+def test_get_job_detail_normalizes_job_id() -> None:
+    gateway = StubJobGateway()
+    controller = JobController(gateway)
+
+    job = asyncio.run(controller.get_job_detail("  job-paused-123  "))
+
+    assert gateway.requested_ids == ["job-paused-123"]
+    assert job == gateway.jobs["job-paused-123"]
+
+
+def test_get_job_detail_rejects_blank_job_ids() -> None:
+    controller = JobController(StubJobGateway())
+
+    with pytest.raises(InvalidJobIdError, match="job_id must not be empty"):
+        asyncio.run(controller.get_job_detail("   "))
+
+
+def test_resume_job_updates_resumable_job_state() -> None:
+    gateway = StubJobGateway()
+    controller = JobController(gateway)
+
+    resumed_job = asyncio.run(controller.resume_job("job-paused-123"))
+
+    assert resumed_job.current_state == "drafting_pr"
+    assert resumed_job.status == "in_progress"
+    assert resumed_job.state_version == 4
+    assert resumed_job.resume_count == 1
+    assert resumed_job.can_resume is True
+    assert resumed_job.last_error is None
+    assert gateway.saved_jobs == [resumed_job]
+
+
+def test_resume_job_allows_in_progress_jobs() -> None:
+    gateway = StubJobGateway()
+    controller = JobController(gateway)
+
+    resumed_job = asyncio.run(controller.resume_job("job-running-456"))
+
+    assert resumed_job.status == "in_progress"
+    assert resumed_job.state_version == 6
+    assert resumed_job.resume_count == 2
+    assert resumed_job.can_resume is True
+
+
+def test_resume_job_rejects_unknown_jobs() -> None:
+    controller = JobController(StubJobGateway())
+
+    with pytest.raises(JobNotFoundError, match="job not found"):
+        asyncio.run(controller.resume_job("job-missing-000"))
+
+
+def test_resume_job_rejects_non_resumable_jobs() -> None:
+    controller = JobController(StubJobGateway())
+
+    with pytest.raises(
+        JobNotResumableError,
+        match="job is not resumable from status 'completed'",
+    ):
+        asyncio.run(controller.resume_job("job-completed-789"))

--- a/src/backend/handlers/README.md
+++ b/src/backend/handlers/README.md
@@ -7,4 +7,6 @@ Purpose
 Starter surfaces in this template
 - `document_handlers.py` — sample document CRUD payload translation plus a starter artifact write on successful document updates.
 - `appointment_handlers.py` — sample appointment payload parsing and response shaping.
-- These files are starter examples. They are not mounted by default in `src/backend/main.py`, so you can replace them with product-specific routes without first unwinding live runtime wiring.
+- `job_handlers.py` — mounted FastAPI router for sample workflow job detail and resume actions.
+- The document and appointment files are starter examples. They are not mounted by default in `src/backend/main.py`, so you can replace them with product-specific routes without first unwinding live runtime wiring.
+- `job_handlers.py` is mounted by default to expose `/jobs/{job_id}/detail` and `/jobs/{job_id}/resume`.

--- a/src/backend/handlers/job_handlers.py
+++ b/src/backend/handlers/job_handlers.py
@@ -1,0 +1,81 @@
+"""FastAPI routes for job detail and resume workflow actions."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+
+from src.backend.controller.job_controller import (
+    InvalidJobIdError,
+    JobController,
+    JobNotFoundError,
+    JobNotResumableError,
+    build_job_controller,
+)
+from src.backend.models.job import JobDetailDTO, ResumeJobResponseDTO
+
+router = APIRouter(prefix="/jobs", tags=["jobs"])
+job_router = router
+
+
+def get_job_controller(request: Request) -> JobController:
+    """Return the configured job controller, creating the sample one if needed."""
+    controller = getattr(request.app.state, "job_controller", None)
+    if controller is None:
+        controller = build_job_controller()
+        request.app.state.job_controller = controller
+    return controller
+
+
+@router.get(
+    "/{job_id}/detail",
+    response_model=JobDetailDTO,
+)
+async def get_job_detail(
+    job_id: str,
+    controller: Annotated[JobController, Depends(get_job_controller)],
+) -> JobDetailDTO:
+    """Return workflow-oriented detail for a single job."""
+    try:
+        return await controller.get_job_detail(job_id)
+    except InvalidJobIdError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except JobNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+
+
+@router.post(
+    "/{job_id}/resume",
+    response_model=ResumeJobResponseDTO,
+)
+async def resume_job(
+    job_id: str,
+    controller: Annotated[JobController, Depends(get_job_controller)],
+) -> ResumeJobResponseDTO:
+    """Resume a paused or in-progress workflow job."""
+    try:
+        job = await controller.resume_job(job_id)
+    except InvalidJobIdError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except JobNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+    except JobNotResumableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+    return ResumeJobResponseDTO(job=job)
+
+
+__all__ = ["get_job_controller", "job_router", "router"]

--- a/src/backend/handlers/job_handlers_test.py
+++ b/src/backend/handlers/job_handlers_test.py
@@ -1,0 +1,75 @@
+"""Tests for mounted job detail and resume routes."""
+
+from fastapi.testclient import TestClient
+
+from src.backend.main import create_app
+
+
+def test_job_detail_route_returns_expected_payload() -> None:
+    response = TestClient(create_app()).get("/jobs/job-paused-123/detail")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "job_id": "job-paused-123",
+        "workflow_type": "pm_tool_workflow",
+        "current_state": "awaiting_requirements",
+        "status": "paused",
+        "state_version": 3,
+        "resume_count": 0,
+        "can_resume": True,
+        "last_error": "Waiting for product requirements",
+    }
+
+
+def test_resume_route_returns_updated_job_state() -> None:
+    client = TestClient(create_app())
+
+    response = client.post("/jobs/job-paused-123/resume")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "job": {
+            "job_id": "job-paused-123",
+            "workflow_type": "pm_tool_workflow",
+            "current_state": "drafting_pr",
+            "status": "in_progress",
+            "state_version": 4,
+            "resume_count": 1,
+            "can_resume": True,
+            "last_error": None,
+        },
+    }
+    assert client.get("/jobs/job-paused-123/detail").json() == {
+        "job_id": "job-paused-123",
+        "workflow_type": "pm_tool_workflow",
+        "current_state": "drafting_pr",
+        "status": "in_progress",
+        "state_version": 4,
+        "resume_count": 1,
+        "can_resume": True,
+        "last_error": None,
+    }
+
+
+def test_job_detail_route_rejects_invalid_job_ids() -> None:
+    response = TestClient(create_app()).get("/jobs/%20%20/detail")
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "job_id must not be empty"}
+
+
+def test_job_detail_route_returns_not_found_for_unknown_jobs() -> None:
+    response = TestClient(create_app()).get("/jobs/job-missing-000/detail")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "job not found"}
+
+
+def test_resume_route_returns_conflict_for_non_resumable_jobs() -> None:
+    response = TestClient(create_app()).post("/jobs/job-completed-789/resume")
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "detail": "job is not resumable from status 'completed'"
+    }

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -2,6 +2,9 @@
 
 from fastapi import FastAPI
 
+from src.backend.controller.job_controller import build_job_controller
+from src.backend.handlers.job_handlers import job_router
+
 
 def create_app() -> FastAPI:
     """Create the FastAPI application used by local workflows."""
@@ -9,6 +12,7 @@ def create_app() -> FastAPI:
         title="FastAPI Template",
         description="Local entrypoint for the reusable FastAPI template.",
     )
+    application.state.job_controller = build_job_controller()
 
     @application.get("/")
     async def read_root() -> dict[str, str]:
@@ -19,6 +23,8 @@ def create_app() -> FastAPI:
     async def read_health() -> dict[str, str]:
         """Return the process health status."""
         return {"status": "ok"}
+
+    application.include_router(job_router)
 
     return application
 

--- a/src/backend/main_test.py
+++ b/src/backend/main_test.py
@@ -14,6 +14,8 @@ def test_create_app_registers_expected_routes() -> None:
 
     assert "/" in route_paths
     assert "/health" in route_paths
+    assert "/jobs/{job_id}/detail" in route_paths
+    assert "/jobs/{job_id}/resume" in route_paths
 
 
 def test_root_endpoint_returns_template_message() -> None:

--- a/src/backend/models/job.py
+++ b/src/backend/models/job.py
@@ -1,0 +1,30 @@
+"""DTOs for the sample job workflow routes."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+JobStatus = Literal["paused", "in_progress", "completed", "failed"]
+
+
+class JobDetailDTO(BaseModel):
+    """Serializable job detail payload for workflow-oriented handlers."""
+
+    job_id: str
+    workflow_type: str
+    current_state: str
+    status: JobStatus
+    state_version: int = Field(ge=1)
+    resume_count: int = Field(default=0, ge=0)
+    can_resume: bool
+    last_error: str | None = None
+
+
+class ResumeJobResponseDTO(BaseModel):
+    """Response payload returned after a successful job resume action."""
+
+    status: Literal["ok"] = "ok"
+    job: JobDetailDTO
+
+
+__all__ = ["JobDetailDTO", "JobStatus", "ResumeJobResponseDTO"]


### PR DESCRIPTION
## Summary
Automated pull request drafted by Codex via Berry.

## Linked Linear Ticket
Fixes BER-131
https://linear.app/baek/issue/BER-131/add-job-detail-and-resume-routes-under-srcbackendhandlers

## Instruction
Implement the approved Berry ticket: Add job detail and resume routes under src/backend/handlers.
Repository: https://github.com/bryanbaek/pypy
Base branch: main

Approved ticket description:
## Summary
Add workflow-oriented backend routes in `src/backend/handlers` to expose job detail retrieval and job resume actions for the PM tool workflow. The new API surface should follow the repository's FastAPI layer boundaries and provide concrete handler endpoints such as `GET /{job_id}/detail` returning `JobDetailDTO` and `POST /{job_id}/resume` to resume an in-progress or paused job.

## Scope
- Define handler routes in `src/backend/handlers` for job workflow actions.
- Add a `GET /{job_id}/detail` endpoint that returns a typed response model such as `JobDetailDTO`.
- Add a `POST /{job_id}/resume` endpoint that triggers the workflow resume path for a given job.
- Wire handlers into the existing backend routing/app registration pattern used by the sample controller/handler structure.
- Implement or connect the minimal controller/service orchestration needed so handlers do not embed business logic directly.
- Add tests covering successful routing, expected response payload shape, and failure behavior for invalid or missing job IDs.
- Update handler/controller documentation if route registration or usage needs to be discoverable for template consumers.

## Acceptance Criteria
- A FastAPI router under `src/backend/handlers` exposes `GET /{job_id}/detail` and `POST /{job_id}/resume` for job workflow operations.
- `GET /{job_id}/detail` returns a typed DTO response (`JobDetailDTO` or equivalent concrete schema) and includes the job identifier plus workflow-relevant state details.
- `POST /{job_id}/resume` calls into a non-handler orchestration layer and returns a clear success response or updated job state for a resumable job.
- Both endpoints are registered in the application so they are available when the backend starts through the normal app bootstrap flow.
- Invalid, unknown, or non-resumable job IDs return explicit HTTP error responses instead of unhandled exceptions.
- Automated tests are added or updated alongside the backend code, following the pattern used in `src/backend/controller/appointment_controller_test.py` where applicable.
- The implementation preserves the template's documented layer boundaries across `src/backend/handlers` and `src/backend/controller`.

## Helpful Files
- `src/backend/handlers/README.md`
- `src/backend/controller/README.md`
- `src/backend/controller/appointment_controller.py`
- `src/backend/controller/appointment_controller_test.py`
- `README.md`
- `pyproject.toml`

## Out of Scope
- Building a frontend UI for job detail or resume actions in `src/frontend`.
- Defining a full end-to-end job engine, queue system, or persistence redesign beyond what is needed to support these two routes.
- Refactoring unrelated sample document or appointment flows.
- Adding unrelated CI, Docker, or GitHub Actions changes unless tests require minimal configuration updates.

## Codex Output
### Initial Draft
> Implemented the job workflow routes under a mounted `/jobs` router. [src/backend/handlers/job_handlers.py](/job/repo/src/backend/handlers/job_handlers.py) now exposes `GET /jobs/{job_id}/detail` and `POST /jobs/{job_id}/resume`, backed by non-handler orchestration in [src/backend/controller/job_controller.py](/job/repo/src/backend/controller/job_controller.py) and typed DTOs in [src/backend/mod...

## Validation
- `just lint`: passed
- `just test`: warning

## Validation Warnings
- Berry opened this PR with `PR_DRAFT_VALIDATION_MODE=warn_only`.
- local validation warnings did not block PR opening.
- `just test` new local validation failures: E AssertionError: README.md is missing expected snippets: ['`docker compose up --build`', 'only mounts `/` and `/health`'], E AssertionError: src/backend/controller/README.md is missing expected snippets: ['starter examples']
- `just test` already fails on `origin/main`: tests/template_readiness_test.py:15: AssertionError, Recipe `test` failed on line 6 with exit code 1

## Berry Cleanup
- Removed generated runtime artifacts before commit: `.pytest_cache`, `.ruff_cache`, `.venv`